### PR TITLE
Fix broken links

### DIFF
--- a/reviews/review_guidelines.md
+++ b/reviews/review_guidelines.md
@@ -18,7 +18,7 @@ When reviewing a PR and leaving comments, make it clear not just what you see as
 
 Reviewers should verify the following checklist against the PR and should make clear if they did any additional checks, such as building the code or testing the code, and if so, under what conditions.
 
-To help you get into the right mindset for reviewing, please see [Gilles Peskine's talk: How to be an effective reviewer](How to be an effective Mbed TLS reviewer.pdf).
+To help you get into the right mindset for reviewing, please see [Gilles Peskine's talk: How to be an effective reviewer](<How to be an effective Mbed TLS reviewer.pdf>).
 
 ### Suitability
 

--- a/security-advisories/advisories/mbedtls-security-advisory-2020-04.md
+++ b/security-advisories/advisories/mbedtls-security-advisory-2020-04.md
@@ -15,10 +15,9 @@ The modular inverse operation as implemented in Mbed TLS is vulnerable to a
 single-trace side channel attack [discovered by Alejandro Cabrera Aldaya and
 Billy Brumley](https://eprint.iacr.org/2020/055) which may allow a local
 adversary to recover the full value of the operand. (Some consequences of this
-attack on [RSA](https://tls.mbed.org/tech-updates/security-advisories/mbedtls-
-security-advisory-2020-02) and [ECDSA](https://tls.mbed.org/tech-
-updates/security-advisories/mbedtls-security-advisory-2019-12) were fixed in
-previous releases.)
+attack on [RSA](https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2020-02)
+and [ECDSA](https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2019-12)
+were fixed in previous releases.)
 
 Mbed TLS, like most libraries implementing ECC, uses projective coordinates to
 represent points internally. It is [known](https://eprint.iacr.org/2003/191)

--- a/security-advisories/advisories/mbedtls-security-advisory-2020-04.md
+++ b/security-advisories/advisories/mbedtls-security-advisory-2020-04.md
@@ -15,9 +15,8 @@ The modular inverse operation as implemented in Mbed TLS is vulnerable to a
 single-trace side channel attack [discovered by Alejandro Cabrera Aldaya and
 Billy Brumley](https://eprint.iacr.org/2020/055) which may allow a local
 adversary to recover the full value of the operand. (Some consequences of this
-attack on [RSA](https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2020-02)
-and [ECDSA](https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2019-12)
-were fixed in previous releases.)
+attack on [RSA](mbedtls-security-advisory-2020-02.md) and
+[ECDSA](mbedtls-security-advisory-2019-12.md) were fixed in previous releases.)
 
 Mbed TLS, like most libraries implementing ECC, uses projective coordinates to
 represent points internally. It is [known](https://eprint.iacr.org/2003/191)

--- a/security-advisories/advisories/mbedtls-security-advisory-2020-07.md
+++ b/security-advisories/advisories/mbedtls-security-advisory-2020-07.md
@@ -12,9 +12,9 @@
 
 The scalar multiplication function in Mbed TLS accepts a random number
 generator (RNG) as an optional argument and, if provided, uses it to protect
-against some attacks, including a [previous attack](https://tls.mbed.org/tech-
-updates/security-advisories/mbedtls-security-advisory-2020-04) by the same
-authors.
+against some attacks, including a [previous
+attack](https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2020-04)
+by the same authors.
 
 It is the caller's responsibility to provide a RNG if protection against side-
 channel attacks is desired; however two groups of functions in Mbed TLS itself

--- a/security-advisories/advisories/mbedtls-security-advisory-2020-07.md
+++ b/security-advisories/advisories/mbedtls-security-advisory-2020-07.md
@@ -13,8 +13,7 @@
 The scalar multiplication function in Mbed TLS accepts a random number
 generator (RNG) as an optional argument and, if provided, uses it to protect
 against some attacks, including a [previous
-attack](https://tls.mbed.org/tech-updates/security-advisories/mbedtls-security-advisory-2020-04)
-by the same authors.
+attack](mbedtls-security-advisory-2020-04.md) by the same authors.
 
 It is the caller's responsibility to provide a RNG if protection against side-
 channel attacks is desired; however two groups of functions in Mbed TLS itself

--- a/security-advisories/advisories/mbedtls-security-advisory-2020-09-3.md
+++ b/security-advisories/advisories/mbedtls-security-advisory-2020-09-3.md
@@ -13,8 +13,8 @@
 
 This is an advisory of a security vulnerability in the TLS specification,
 which has very limited impact on Mbed TLS: the Raccoon attack (for details see
-the [website](https://raccoon-attack.com/) and the [paper](https://raccoon-
-attack.com/RacoonAttack.pdf)).
+the [website](https://raccoon-attack.com/) and the
+[paper](https://raccoon-attack.com/RacoonAttack.pdf)).
 
 In the TLS protocol, the calculation of the premaster secret from the finite-
 field Diffie-Hellman (FFDH) shared secret strips the leading zero bytes. If

--- a/security-advisories/advisories/polarssl-security-advisory-2013-03.md
+++ b/security-advisories/advisories/polarssl-security-advisory-2013-03.md
@@ -86,7 +86,7 @@ patch.
 
 ## Advice
 
-We strongly advise you to consider upgrading to version [1.1.7](/tech-
-updates/releases/polarssl-1.1.7-released) or [1.2.8](/tech-
-updates/releases/polarssl-1.2.8-released), or apply the provided path, if
-outside parties are present or can connect to your network.
+We strongly advise you to consider upgrading to version
+[1.1.7](/tech-updates/releases/polarssl-1.1.7-released) or
+[1.2.8](/tech-updates/releases/polarssl-1.2.8-released), or apply the provided
+path, if outside parties are present or can connect to your network.

--- a/security-advisories/advisories/polarssl-security-advisory-2013-04.md
+++ b/security-advisories/advisories/polarssl-security-advisory-2013-04.md
@@ -48,7 +48,7 @@ patch.
 ## Advice
 
 We strongly advise you to consider upgrading to the 1.3 branch, or otherwise
-apply the patch, upgrade to version [1.1.8](/tech-
-updates/releases/polarssl-1.1.8-released), [1.2.9](/tech-
-updates/releases/polarssl-1.2.9-released) if outside parties are present or
-can connect to your network.
+apply the patch, upgrade to version
+[1.1.8](/tech-updates/releases/polarssl-1.1.8-released),
+[1.2.9](/tech-updates/releases/polarssl-1.2.9-released) if outside parties are
+present or can connect to your network.

--- a/security-advisories/advisories/polarssl-security-advisory-2014-01.md
+++ b/security-advisories/advisories/polarssl-security-advisory-2014-01.md
@@ -29,7 +29,7 @@ directly from the services and users and to impersonate services and users."_
 [[1]](http://heartbleed.com/)
 
 The attack has been added to the known attacks in [our Security
-Center](/security).
+Center](../security-advisories.md).
 
 ## Impact
 

--- a/security-advisories/advisories/polarssl-security-advisory-2014-03-poodle-attack-on-ssl-v3.md
+++ b/security-advisories/advisories/polarssl-security-advisory-2014-03-poodle-attack-on-ssl-v3.md
@@ -14,8 +14,8 @@ SSLv3.
 
 This Security Advisory only describes the impact and workaround for the POODLE
 attack. A more detailed explanation can be found in our post that puts [the
-POODLE attack in perspective](/tech-updates/blog/sslv3-and-poodle-in-
-perspective).
+POODLE attack in
+perspective](/tech-updates/blog/sslv3-and-poodle-in-perspective).
 
 ## Impact of POODLE
 


### PR DESCRIPTION
Several links in the documentation didn't conform to Markdown syntax:
* Link destination must not have spaces in them, unless surrounded by "<>" characters.
* Link destinations must not have newlines in them at all.

Some links were also referencing locations under the old tls.mbed.org website.

Unknown internal references are safely ignored with a warning, and so have been left in place, until their content is migrated to the new website.