### PR TITLE
Add / remove syntax highlighting from code blocks where necessary

### DIFF
--- a/reviews/review_guidelines.md
+++ b/reviews/review_guidelines.md
@@ -64,18 +64,17 @@ To help you get into the right mindset for reviewing, please see [Gilles Peskine
     * Detailed description of commit in commit message
     * On its own line starting with "Fixes ", a comma separated list of GitHub issues that this commit fixes. Repeat the "fixes" keyword for each issue so that GitHub can read the issues. GitHub will close the issue automatically, so if it takes multiple commits to fix an issue, just list "Fixes" on the most recent commit.
   * Example:
- ```
-Add tests for rsa_deduce_moduli()
 
-Add tests for the new library function mbedtls_rsa_deduce_moduli() for
-deducing the prime factors (P,Q) of an RSA modulus N from knowledge of a
-pair (D,E) of public and private exponent:
+        Add tests for rsa_deduce_moduli()
 
-- Two toy examples that can be checked by hand, one fine and with bad parameters
-- Two real world examples, one fine and one with bad parameters
+        Add tests for the new library function mbedtls_rsa_deduce_moduli() for
+        deducing the prime factors (P,Q) of an RSA modulus N from knowledge of a
+        pair (D,E) of public and private exponent:
 
-Fixes #416, fixes #417
- ```
+        - Two toy examples that can be checked by hand, one fine and with bad parameters
+        - Two real world examples, one fine and one with bad parameters
+
+        Fixes #416, fixes #417
 * Commit messages must NOT contain the following
   * References to issue trackers other than the public GitHub repository 
 * Correctness

--- a/security-advisories/advisories/polarssl-security-advisory-2013-03.md
+++ b/security-advisories/advisories/polarssl-security-advisory-2013-03.md
@@ -44,44 +44,46 @@ patch.
 
 
 
-    diff --git a/include/polarssl/x509.h b/include/polarssl/x509.h
-    index 87151c9..296925f 100644
-    --- a/include/polarssl/x509.h
-    +++ b/include/polarssl/x509.h
-    @@ -425,6 +425,18 @@ extern "C" {
+```diff
+diff --git a/include/polarssl/x509.h b/include/polarssl/x509.h
+index 87151c9..296925f 100644
+--- a/include/polarssl/x509.h
++++ b/include/polarssl/x509.h
+@@ -425,6 +425,18 @@ extern "C" {
 
-     /** \ingroup x509_module */
-     /**
-    + * \brief          Parse a single DER formatted certificate and add it
-    + *                 to the chained list.
-    + *
-    + * \param chain    points to the start of the chain
-    + * \param buf      buffer holding the certificate DER data
-    + * \param buflen   size of the buffer
-    + *
-    + * \return         0 if successful, or a specific X509 or PEM error code
-    + */
-    +int x509parse_crt_der( x509_cert *chain, const unsigned char *buf, size_t buflen );
-    +
-    +/**
-      * \brief          Parse one or more certificates and add them
-      *                 to the chained list. Parses permissively. If some
-      *                 certificates can be parsed, the result is the number
-    diff --git a/library/ssl_tls.c b/library/ssl_tls.c
-    index 9087ab4..e0cddf8 100644
-    --- a/library/ssl_tls.c
-    +++ b/library/ssl_tls.c
-    @@ -2375,8 +2375,8 @@ int ssl_parse_certificate( ssl_context *ssl )
-                 return( POLARSSL_ERR_SSL_BAD_HS_CERTIFICATE );
-             }
+ /** \ingroup x509_module */
+ /**
++ * \brief          Parse a single DER formatted certificate and add it
++ *                 to the chained list.
++ *
++ * \param chain    points to the start of the chain
++ * \param buf      buffer holding the certificate DER data
++ * \param buflen   size of the buffer
++ *
++ * \return         0 if successful, or a specific X509 or PEM error code
++ */
++int x509parse_crt_der( x509_cert *chain, const unsigned char *buf, size_t buflen );
++
++/**
+  * \brief          Parse one or more certificates and add them
+  *                 to the chained list. Parses permissively. If some
+  *                 certificates can be parsed, the result is the number
+diff --git a/library/ssl_tls.c b/library/ssl_tls.c
+index 9087ab4..e0cddf8 100644
+--- a/library/ssl_tls.c
++++ b/library/ssl_tls.c
+@@ -2375,8 +2375,8 @@ int ssl_parse_certificate( ssl_context *ssl )
+             return( POLARSSL_ERR_SSL_BAD_HS_CERTIFICATE );
+         }
 
-    -        ret = x509parse_crt( ssl->session_negotiate->peer_cert, ssl->in_msg + i,
-    -                             n );
-    +        ret = x509parse_crt_der( ssl->session_negotiate->peer_cert,
-    +                                 ssl->in_msg + i, n );
-             if( ret != 0 )
-             {
-                 SSL_DEBUG_RET( 1, " x509parse_crt", ret );
+-        ret = x509parse_crt( ssl->session_negotiate->peer_cert, ssl->in_msg + i,
+-                             n );
++        ret = x509parse_crt_der( ssl->session_negotiate->peer_cert,
++                                 ssl->in_msg + i, n );
+         if( ret != 0 )
+         {
+             SSL_DEBUG_RET( 1, " x509parse_crt", ret );
+```
 
 
 ## Advice

--- a/security-advisories/advisories/polarssl-security-advisory-2013-04.md
+++ b/security-advisories/advisories/polarssl-security-advisory-2013-04.md
@@ -30,19 +30,21 @@ patch.
 
 
 
-    diff --git a/library/ssl_tls.c b/library/ssl_tls.c
-    index 27f2172..a5d1cb1 100644
-    --- a/library/ssl_tls.c
-    +++ b/library/ssl_tls.c
-    @@ -1159,7 +1159,7 @@ int ssl_read_record( ssl_context *ssl )
-             /*
-              * TLS encrypted messages can have up to 256 bytes of padding
-              */
-    -        if( ssl->minor_ver == SSL_MINOR_VERSION_1 &&
-    +        if( ssl->minor_ver >= SSL_MINOR_VERSION_1 &&
-                 ssl->in_msglen > ssl->minlen + SSL_MAX_CONTENT_LEN + 256 )
-             {
-                 SSL_DEBUG_MSG( 1, ( "bad message length" ) );
+```diff
+diff --git a/library/ssl_tls.c b/library/ssl_tls.c
+index 27f2172..a5d1cb1 100644
+--- a/library/ssl_tls.c
++++ b/library/ssl_tls.c
+@@ -1159,7 +1159,7 @@ int ssl_read_record( ssl_context *ssl )
+         /*
+          * TLS encrypted messages can have up to 256 bytes of padding
+          */
+-        if( ssl->minor_ver == SSL_MINOR_VERSION_1 &&
++        if( ssl->minor_ver >= SSL_MINOR_VERSION_1 &&
+             ssl->in_msglen > ssl->minlen + SSL_MAX_CONTENT_LEN + 256 )
+         {
+             SSL_DEBUG_MSG( 1, ( "bad message length" ) );
+```
 
 
 ## Advice

--- a/security-advisories/advisories/polarssl-security-advisory-2014-04.md
+++ b/security-advisories/advisories/polarssl-security-advisory-2014-04.md
@@ -44,19 +44,21 @@ The fix is a one-line addition to _asn1parse.c_ :
 
 
 
-    diff --git a/library/asn1parse.c b/library/asn1parse.c
-    index a3a2b56..e2117bf 100644
-    --- a/library/asn1parse.c
-    +++ b/library/asn1parse.c
-    @@ -278,6 +278,8 @@ int asn1_get_sequence_of( unsigned char **p,
-                 if( cur->next == NULL )
-                     return( POLARSSL_ERR_ASN1_MALLOC_FAILED );
+```diff
+diff --git a/library/asn1parse.c b/library/asn1parse.c
+index a3a2b56..e2117bf 100644
+--- a/library/asn1parse.c
++++ b/library/asn1parse.c
+@@ -278,6 +278,8 @@ int asn1_get_sequence_of( unsigned char **p,
+             if( cur->next == NULL )
+                 return( POLARSSL_ERR_ASN1_MALLOC_FAILED );
 
-    +            memset( cur->next, 0, sizeof( asn1_sequence ) );
-    +
-                 cur = cur->next;
-             }
++            memset( cur->next, 0, sizeof( asn1_sequence ) );
++
+             cur = cur->next;
          }
+     }
+```
 
 
 ## Workaround and resolution


### PR DESCRIPTION
This PR adds syntax highlighting to the `diff` code blocks present in old security advisories,
and removes spurious syntax highlighting from the example commit message in the review guidelines.

It also corrects the indentation of said commit message with regards to the list it's a part of.