### PR TITLE
Remove links to empty indices and search page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -24,10 +24,3 @@ For more information, see the following:
    security-advisories/security-advisories.md
    maintainers.md
    CONTRIBUTING.md
-
-Indices and tables
-==================
-
-* :ref:`genindex`
-* :ref:`modindex`
-* :ref:`search`


### PR DESCRIPTION
The indices would automatically populate with function definitions, which are not present in the unversioned documentation.
If we decide to manually create a traditional word-index, we can re-add the link to the index page.

The search page is empty when using readthedocs's default theme.
Search is instead handled through the sidebar.