### PR TITLE
Remove the .html extensions from page URLs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,9 +13,9 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
-   configuration: conf.py
+  configuration: conf.py
 
 # Optionally declare the Python requirements required to build your docs
 python:
-   install:
-   - requirements: requirements.txt
+  install:
+  - requirements: requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,7 @@ build:
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
+  builder: dirhtml
   configuration: conf.py
 
 # Optionally declare the Python requirements required to build your docs


### PR DESCRIPTION
The old website used page URLs with no .html extension. To mimic this,
we need to use the dirhtml Sphinx builder.

Readthedocs supports adding automatic redirects from one builder to the
other, so the .html URLs should be redirected automatically.
