### PR TITLE
Do not use loose modules

### DIFF
--- a/kb/how-to/using-loose-modules-without-the-full-library.md
+++ b/kb/how-to/using-loose-modules-without-the-full-library.md
@@ -24,7 +24,7 @@ The documentation of `MBEDTLS_ENTROPY_C` states that it requires either `MBEDTLS
 
 You decide to use HMAC\_DRBG, and use SHA-512 as the hash function both for entropy and for the DRBG. As a conseqence, you write the following configuration file:
 
-```
+```c
 #define MBEDTLS_ENTROPY_C
 #define MBEDTLS_HMAC_DRBG_C
 #define MBEDTLS_MD_C
@@ -36,7 +36,7 @@ You decide to use HMAC\_DRBG, and use SHA-512 as the hash function both for entr
 In Mbed TLS 2.x, the configuration file is located at `include/mbedtls/config.h`.
 
 You should add the following line at the end of your configuration file:
-```
+```c
 #include "mbedtls/check_config.h"
 ```
 This will cause compilation errors with descriptive messages if the configuration is inconsistent.
@@ -50,19 +50,19 @@ If you prefer, you can include the Mbed TLS source files in your own build scrip
 ### Compiling with Mbed TLS headers
 
 Both when building your application and when building Mbed TLS source files, make sure that the `include` directory of the Mbed TLS source tree is present in the header search path. For example, if Mbed TLS is in the subdirectory `external/mbedtls`:
-```
-cc -I external/mbedtls/include …
+```console
+$ cc -I external/mbedtls/include …
 ```
 
 If you have a custom configuration file with the same name in a different directory, it must come first on the header search path. For example, if your Mbed TLS configuration file is located at `configs/mbedtls/mbedtls_config.h` and the Mbed TLS source tree is located at `external/mbedtls`:
-```
-cc -I configs -I external/mbedtls/include …
+```console
+$ cc -I configs -I external/mbedtls/include …
 ```
 
 Recall that alternatively, you can give your configuration file a different name and specify its location with the preprocessor symbol `MBEDTLS_CONFIG_FILE`. For example, if your Mbed TLS configuration file is located at `my_mbedtls_config.h` and the Mbed TLS source tree is located at `external/mbedtls`.
 
-```
-cc -DMBEDTLS_CONFIG_FILE='"my_mbedtls_config.h"' -I configs -I external/mbedtls/include …
+```console
+$ cc -DMBEDTLS_CONFIG_FILE='"my_mbedtls_config.h"' -I configs -I external/mbedtls/include …
 ```
 
 Note that **you must pass the same configuration when building Mbed TLS and building your application**. Passing a different configuration is likely to result in misbehavior at runtime.

--- a/kb/how-to/using-loose-modules-without-the-full-library.md
+++ b/kb/how-to/using-loose-modules-without-the-full-library.md
@@ -45,7 +45,7 @@ This will cause compilation errors with descriptive messages if the configuratio
 
 Mbed TLS comes with build scripts for GNU make (`Makefile`), CMake (`CMakeLists.txt`) and Visual Studio (`visualc/VS2010/mbedTLS.sln`). By default, these create static libraries `mbedcrypto`, `mbedx509` and `mbedtls` which you can link into your application. (You don't need to link `mbedx509` or `mbedtls` if you don't use these features.) For more information, see [How to compile and build Mbed TLS](../compiling-and-building/how-do-i-build-compile-mbedtls.md).
 
-If you prefer, you can include the Mbed TLS source files in your own build scripts. All the library code is in the `library` subdirectory, except for aa few features that use code from the `3rdparty` directory tree. All the public headers are in the `include` directory tree.
+If you prefer, you can include the Mbed TLS source files in your own build scripts. All the library code is in the `library` subdirectory, except for a few features that use code from the `3rdparty` directory tree. All the public headers are in the `include` directory tree.
 
 ### Compiling with Mbed TLS headers
 

--- a/kb/how-to/using-loose-modules-without-the-full-library.md
+++ b/kb/how-to/using-loose-modules-without-the-full-library.md
@@ -22,7 +22,7 @@ For example, suppose you want a cryptographically secure random generator and no
 
 The documentation of `MBEDTLS_ENTROPY_C` states that it requires either `MBEDTLS_SHA512_C` or `MBEDTLS_SHA256_C`. The CTR\_DRBG module requires `MBEDTLS_AES_C`. The HMAC\_DRBG module requires `MBEDTLS_MD_C`, which in turn requires at least one hash module.
 
-You decide to use HMAC\_DRBG, and use SHA-512 as the hash function both for entropy and for the DRBG. As a conseqence, you write the following configuration file:
+You decide to use HMAC\_DRBG, and use SHA-512 as the hash function both for entropy and for the DRBG. As a consequence, you write the following configuration file:
 
 ```c
 #define MBEDTLS_ENTROPY_C

--- a/kb/how-to/using-loose-modules-without-the-full-library.md
+++ b/kb/how-to/using-loose-modules-without-the-full-library.md
@@ -20,7 +20,7 @@ For more information, see [How to configure Mbed TLS](../compiling-and-building/
 
 For example, suppose you want a cryptographically secure random generator and nothing else. A random generator consists of two parts: an entropy source, and a pseudorandom generator seeded by the entropy source. Mbed TLS provides an interface to the system's entropy sources in the `entropy` module enabled by `MBEDTLS_ENTROPY_C`. For the pseudorandom generator, there are two choices: CTR\_DRBG or HMAC\_DRBG, enabled with `MBEDTLS_CTR_DRBG_C` and `MBEDTLS_HMAC_DRBG_C` respectively.
 
-The documentation of `MBEDTLS_ENTROPY_C` states that it requires either `MBEDTLS_SHA512_C` or `MBEDTLS_SHA256_C`. The CTR\_DRBG module requires ``MBEDTLS_AES_C`. The HMAC\_DRBG module requires `MBEDTLS_MD_C`, which in turn requires at least one hash module.
+The documentation of `MBEDTLS_ENTROPY_C` states that it requires either `MBEDTLS_SHA512_C` or `MBEDTLS_SHA256_C`. The CTR\_DRBG module requires `MBEDTLS_AES_C`. The HMAC\_DRBG module requires `MBEDTLS_MD_C`, which in turn requires at least one hash module.
 
 You decide to use HMAC\_DRBG, and use SHA-512 as the hash function both for entropy and for the DRBG. As a conseqence, you write the following configuration file:
 


### PR DESCRIPTION
The development team has not actively supported loose modules for several
years and discourages its use. Replace the instructions for using loose
modules by instructions for using the original mbedtls source tree with
a minimal configuration.
