### PR TITLE
Minor knowledge base updates for Mbed TLS 2.2x and 3.x

### DIFF
--- a/kb/compiling-and-building/compile-mbedtls-to-a-static-library-in-eclipse-cdt.md
+++ b/kb/compiling-and-building/compile-mbedtls-to-a-static-library-in-eclipse-cdt.md
@@ -23,7 +23,7 @@ This tutorial will show how to compile Mbed TLS to a static `.a ` library file i
 * Create your new C project by choosing  **File** > **New C Project**.
 * The **C Project** dialog pops up:
 
-![Eclipse new project popup](/kb/assets/mbedtls-tutorial-eclipse-static-lib-1.png)
+![Eclipse new project popup](../assets/mbedtls-tutorial-eclipse-static-lib-1.png)
 
 * In the **Project name** field, enter your project name (for example, "Mbedtls").
 
@@ -49,13 +49,13 @@ In this step, you import the Mbed TLS code into the project and make it ready fo
 Since we are using a mixture of Windows- and Unix-based tools, we will encounter our first problem:
 
 **Option 1:** Windows-style path:
-![Windows-style path](/kb/assets/mbedtls-tutorial-eclipse-static-lib-2.png)
+![Windows-style path](../assets/mbedtls-tutorial-eclipse-static-lib-2.png)
 
 If you add a Windows-style path like `C:/mbed/include`, project rebuilds will fail and `make` returns a `multiple target` error caused by the ``:`` character in your path.
 One solution is to always clean the project before a new rebuild.
 
 **Option 2:** Cygwin-style path:
-![Cygwin-style path](/kb/assets/mbedtls-tutorial-eclipse-static-lib-3.png)
+![Cygwin-style path](../assets/mbedtls-tutorial-eclipse-static-lib-3.png)
 
 If you add a Cygwin-style path like `/cygdrive/c/mbed/include` Eclipse will warn you that the directory cannot be found, and all your includes get an unresolved warning.
 **The project will compile anyway.**
@@ -63,7 +63,7 @@ If you add a Cygwin-style path like `/cygdrive/c/mbed/include` Eclipse will warn
 * Right click on your project and click **Import**.
 * Choose **General** > **Filesystem** and  **Next**.
 
-![Import Code](/kb/assets/mbedtls-tutorial-eclipse-static-lib-4.png)
+![Import Code](../assets/mbedtls-tutorial-eclipse-static-lib-4.png)
 
 * Navigate to the **MbedTLS** library folder
 * Select all the `.c` files

--- a/kb/compiling-and-building/how-do-i-configure-mbedtls.md
+++ b/kb/compiling-and-building/how-do-i-configure-mbedtls.md
@@ -4,7 +4,7 @@ Mbed TLS should build out-of-the box on a large variety of platforms. However, y
 
 ## The configuration file
 
-The default configuration file is located in `include/mbedtls/config.h`. It is [fully documented](/api/config_8h.html) and contains the following sections:
+The default configuration file is located in `include/mbedtls/mbedtls_config.h` (`include/mbedtls/config.h` up to Mbed TLS 2.28). It is [fully documented](/api/config_8h.html) and contains the following sections:
 
 * Select options depending on your platform in **System support**: does your compiler support inline assembly, does your libc/network stack provide IPv6, and so on.
 * Select which features you want to enable for corresponding modules in **Mbed TLS feature support**: which TLS version to support, which key exchanges, which specific elliptic curves, and so on.
@@ -18,7 +18,7 @@ You can edit the configuration file manually with a text editor of your choice. 
     scripts/config.pl unset <name>
     scripts/config.pl set <name> [<value>]
     ```
-The `config.pl` script automatically finds the `config.h` file when it runs this way from Mbed TLS' root directory. If you want to run it from another directory or on another configuration file (see below), you need to use the `-f` option.
+The `config.pl` script automatically finds the `mbedtls_config.h` file when it runs this way from Mbed TLS' root directory. If you want to run it from another directory or on another configuration file (see below), you need to use the `-f` option.
 
 ## Alternative configuration files
 
@@ -34,7 +34,7 @@ or, using **Cmake**:
     CFLAGS="-Ipath/to/config -DMBEDTLS_CONFIG_FILE='<my_config.h>'" cmake .
     make
     ```
-We provide a `check_config.h` file that checks the consistency of the configuration file. We highly recommended to `include` it at the end of your custom configuration file. If you use the above setup, you may need to adapt the `include` directive depending on your compiler.
+**Mbed TLS 2.2x only:** We provide a `check_config.h` file that checks the consistency of the configuration file. We highly recommended to `include` it at the end of your custom configuration file. If you use the above setup, you may need to adapt the `include` directive depending on your compiler. (Since Mbed TLS 3.0, `check_config.h` is included automatically.)
 
 ## Example configurations
 

--- a/kb/compiling-and-building/how-do-i-configure-mbedtls.md
+++ b/kb/compiling-and-building/how-do-i-configure-mbedtls.md
@@ -13,12 +13,12 @@ The default configuration file is located in `include/mbedtls/mbedtls_config.h` 
 
 ## The configuration script
 
-You can edit the configuration file manually with a text editor of your choice. In some cases, however, it may be useful to set options in a more programmatic way. We provide a Perl script `scripts/config.pl` for doing so:
+You can edit the configuration file manually with a text editor of your choice. In some cases, however, it may be useful to set options in a more programmatic way. We provide a Python script `scripts/config.py` for doing so:
     ```
-    scripts/config.pl unset <name>
-    scripts/config.pl set <name> [<value>]
+    scripts/config.py unset <name>
+    scripts/config.py set <name> [<value>]
     ```
-The `config.pl` script automatically finds the `mbedtls_config.h` file when it runs this way from Mbed TLS' root directory. If you want to run it from another directory or on another configuration file (see below), you need to use the `-f` option.
+The `config.py` script automatically finds the `mbedtls_config.h` file when it runs this way from Mbed TLS' root directory. If you want to run it from another directory or on another configuration file (see below), you need to use the `-f` option.
 
 ## Alternative configuration files
 

--- a/kb/compiling-and-building/how-do-i-configure-mbedtls.md
+++ b/kb/compiling-and-building/how-do-i-configure-mbedtls.md
@@ -38,6 +38,6 @@ or, using **Cmake**:
 
 ## Example configurations
 
-We provide example configurations in the `configs` directory. These are often minimal configurations for a specific goal, such as supporting the `NSA suite B TLS` profile. They also often include settings to [reduce resource usage](/kb/how-to/reduce-polarssl-memory-and-storage-footprint.md).
+We provide example configurations in the `configs` directory. These are often minimal configurations for a specific goal, such as supporting the `NSA suite B TLS` profile. They also often include settings to [reduce resource usage](../how-to/reduce-polarssl-memory-and-storage-footprint.md).
 
 <!---",how-do-i-configure-mbedtls,"Short article on configuring Mbed TLS before compilation.",,"configuration, compiling",published,"2014-11-14 12:40:00",6,21074,"2015-07-24 11:53:00","Manuel PÃ©gouriÃ©-Gonnard"--->

--- a/kb/compiling-and-building/mbedtls-failed-to-compile.md
+++ b/kb/compiling-and-building/mbedtls-failed-to-compile.md
@@ -2,7 +2,7 @@
 
 This can happen. We cannot anticipate all interactions between software version and platforms.
 
-We have an ever-expanding set of hardware and OS platforms on which Mbed TLS is automatically built. Please [open a discussion or file a ticket on Github](https://github.com/ARMmbed/mbedtls/issues), or [contact us directly](/contact).
+We have an ever-expanding set of hardware and OS platforms on which Mbed TLS is automatically built. Please [open a discussion or file a ticket on Github](https://github.com/Mbed-TLS/mbedtls/issues), or [contact us directly](/contact).
 
 Please provide us with as much information as possible on:
 

--- a/kb/compiling-and-building/using-mbedtls-in-microsoft-visual-studio-2015.md
+++ b/kb/compiling-and-building/using-mbedtls-in-microsoft-visual-studio-2015.md
@@ -1,6 +1,6 @@
 # Arm Mbed TLS in Microsoft Visual Studio 2015
 
-This tutorial shows how to get started with the Mbed TLS cryptography library in a Windows environment, using Microsoft Visual Studio 2015. This tutorial uses the sample client application (from [this example](/kb/how-to/mbedtls-tutorial.md)). This application sends an HTTP request to read an HTML page from a server.This tutorial uses Mbed TLS to enable encrypting our communication with the server with TLS. Note that Mbed TLS supports Visual Studio starting from version 2010.
+This tutorial shows how to get started with the Mbed TLS cryptography library in a Windows environment, using Microsoft Visual Studio 2015. This tutorial uses the sample client application (from [this example](../how-to/mbedtls-tutorial.md)). This application sends an HTTP request to read an HTML page from a server.This tutorial uses Mbed TLS to enable encrypting our communication with the server with TLS. Note that Mbed TLS supports Visual Studio starting from version 2010.
 
 There are two possible ways to build Mbed TLS on Windows:
 
@@ -280,7 +280,7 @@ You can use Mbed TLS to create a TLS server and client by providing a framework 
 
 ### Modify application to use TLS
 
-[This tutorial](/kb/how-to/mbedtls-tutorial.md) describes how to add Mbed TLS to the sample application. For now, replace the code in the `client.c` file by copying and pasting this code over the existing code:
+[This tutorial](../how-to/mbedtls-tutorial.md) describes how to add Mbed TLS to the sample application. For now, replace the code in the `client.c` file by copying and pasting this code over the existing code:
 
 ```
 #include <string.h>

--- a/kb/cryptography/elliptic-curve-performance-nist-vs-brainpool.md
+++ b/kb/cryptography/elliptic-curve-performance-nist-vs-brainpool.md
@@ -3,7 +3,7 @@
 ## Introduction
 Using different elliptic curves has a high impact on the performance of ECDSA, ECDHE and ECDH operations. Each type of curve was designed with a different primary goal in mind, which is reflected in the performance of the specific curves.
 
-The following numbers, measured with Mbed TLS 2.18.0  on a 3.40 GHz Core i7, are only indicative of the relative speed of the various curves. The absolute value depends on your platform. These numbers also use the default settings for speed-memory trade-offs, and you can read more about [Reducing Mbed TLS memory and storage footprint](/kb/how-to/reduce-polarssl-memory-and-storage-footprint.md).
+The following numbers, measured with Mbed TLS 2.18.0  on a 3.40 GHz Core i7, are only indicative of the relative speed of the various curves. The absolute value depends on your platform. These numbers also use the default settings for speed-memory trade-offs, and you can read more about [Reducing Mbed TLS memory and storage footprint](../how-to/reduce-polarssl-memory-and-storage-footprint.md).
 
 ## ECDSA Performance
 

--- a/kb/cryptography/providing-diffie-hellman-or-dhm-parameters.md
+++ b/kb/cryptography/providing-diffie-hellman-or-dhm-parameters.md
@@ -6,7 +6,7 @@ Developers have the option to set the DHM parameters for SSL servers with `mbedt
 
 ## Default DHM parameters
 
-The DHM parameters that the TLS handshake uses are set by default to the 2048-bit MODP parameters from [RFC 3526](https://www.ietf.org/rfc/rfc3526.txt) (`MBEDTLS_DHM_RFC3526_MODP_2048_P_BIN` and `MBEDTLS_DHM_RFC3526_MODP_2048_G_BIN`). From a security perspective, it is desirable to use a larger value, unless you have clients for which this will cause interoperability issues. Larger values are provided in [dhm.h](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/dhm.h).
+The DHM parameters that the TLS handshake uses are set by default to the 2048-bit MODP parameters from [RFC 3526](https://www.ietf.org/rfc/rfc3526.txt) (`MBEDTLS_DHM_RFC3526_MODP_2048_P_BIN` and `MBEDTLS_DHM_RFC3526_MODP_2048_G_BIN`). From a security perspective, it is desirable to use a larger value, unless you have clients for which this will cause interoperability issues. Larger values are provided in [dhm.h](https://github.com/Mbed-TLS/mbedtls/blob/development/include/mbedtls/dhm.h).
 
 ## Custom parameters
 

--- a/kb/cryptography/rsa-key-pair-generator.md
+++ b/kb/cryptography/rsa-key-pair-generator.md
@@ -4,7 +4,7 @@ To use RSA with Mbed TLS or any other application, you will most likely need an 
 
 ## Building the RSA key pair generator
 
-Mbed TLS ships with the source code for an RSA key pair generator application, called **gen_key**. To build the executable for the application, please check out the [building Mbed TLS](/kb/compiling-and-building/how-do-i-build-compile-mbedtls.md).
+Mbed TLS ships with the source code for an RSA key pair generator application, called **gen_key**. To build the executable for the application, please check out the [building Mbed TLS](../compiling-and-building/how-do-i-build-compile-mbedtls.md).
 
 After the compilation, the executable is often located in `programs/pkey/gen_key`.
 

--- a/kb/cryptography/use-external-rsa-private-key.md
+++ b/kb/cryptography/use-external-rsa-private-key.md
@@ -16,4 +16,4 @@ You can then use the normal `mbedtls_set_own_cert()` function. From the perspect
 
 If you are using a smartcard, you don't have to write your own logic. You can use the `libpkcs11-helper` library.
 
-Mbed TLS includes a helper class for using the `libpkcs11-helper` when you enable `MBEDTLS_PKCS11_C` in `config.h`. See [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md).
+Mbed TLS includes a helper class for using the `libpkcs11-helper` when you enable `MBEDTLS_PKCS11_C` in `config.h`. See [How do I configure Mbed TLS](../compiling-and-building/how-do-i-configure-mbedtls.md).

--- a/kb/development/hw_acc_guidelines.md
+++ b/kb/development/hw_acc_guidelines.md
@@ -2,9 +2,9 @@
 
 As mentioned in the [Mbed TLS Abstraction layers article](/kb/generic/abstraction-layers.md), Mbed TLS supports alternative implementation for most of its cryptography modules. A common use case is for hardware accelerated cryptography engines. There are a couple of methods for alternative implementations: specific function replacement and full module replacement. The latter is the more common one.
 
-The [configuration file (`mbedtls_config.h`)](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/mbedtls_config.h) lists the cryptography modules, which you can replace with alternative implementation. An alternative implementation of a module is effectively a driver for a piece of cryptographic hardware. These are named `MBEDTLS_<MODULE NAME>_ALT`. In order to support an alternative implementation for a module, uncomment the corresponding `*_ALT` definition. Function replacement is based on the function name, upper-cased, with the suffix `_ALT`. To support a hardware entropy source, enable `MBEDTLS_ENTROPY_HARDWARE_ALT` in the configuration file.  
+The [configuration file (`mbedtls_config.h`)](https://github.com/Mbed-TLS/mbedtls/blob/development/include/mbedtls/mbedtls_config.h) lists the cryptography modules, which you can replace with alternative implementation. An alternative implementation of a module is effectively a driver for a piece of cryptographic hardware. These are named `MBEDTLS_<MODULE NAME>_ALT`. In order to support an alternative implementation for a module, uncomment the corresponding `*_ALT` definition. Function replacement is based on the function name, upper-cased, with the suffix `_ALT`. To support a hardware entropy source, enable `MBEDTLS_ENTROPY_HARDWARE_ALT` in the configuration file.  
 
-**Note: For RSA and ECP function replacement, the behavior is different. Refer to the [ECP internal header](https://github.com/ARMmbed/mbedtls/blob/development/library/ecp_internal_alt.h) for more information.**  
+**Note: For RSA and ECP function replacement, the behavior is different. Refer to the [ECP internal header](https://github.com/Mbed-TLS/mbedtls/blob/development/library/ecp_internal_alt.h) for more information.**  
 
 Note: for more information about the configuration file, see [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md).
 

--- a/kb/development/hw_acc_guidelines.md
+++ b/kb/development/hw_acc_guidelines.md
@@ -2,9 +2,11 @@
 
 As mentioned in the [Mbed TLS Abstraction layers article](/kb/generic/abstraction-layers.md), Mbed TLS supports alternative implementation for most of its cryptography modules. A common use case is for hardware accelerated cryptography engines. There are a couple of methods for alternative implementations: specific function replacement and full module replacement. The latter is the more common one.
 
-The [configuration file](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/config.h) contains the cryptography modules, which you can replace with alternative implementation. An alternative implementation of a module is effectively a driver for a piece of cryptographic hardware. These are named `MBEDTLS_<MODULE NAME>_ALT`. In order to support an alternative implementation for a module, uncomment the corresponding `*_ALT` definition. Function replacement is based on the function name, upper-cased, with the suffix `_ALT`. To support a hardware entropy source, enable `MBEDTLS_ENTROPY_HARDWARE_ALT` in the configuration file.  
+The [configuration file (`mbedtls_config.h`)](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/mbedtls_config.h) lists the cryptography modules, which you can replace with alternative implementation. An alternative implementation of a module is effectively a driver for a piece of cryptographic hardware. These are named `MBEDTLS_<MODULE NAME>_ALT`. In order to support an alternative implementation for a module, uncomment the corresponding `*_ALT` definition. Function replacement is based on the function name, upper-cased, with the suffix `_ALT`. To support a hardware entropy source, enable `MBEDTLS_ENTROPY_HARDWARE_ALT` in the configuration file.  
 
-**Note: For `ECP` function replacement, the behavior is different. Refer to the [ECP module](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/ecp_internal.h) for more information.**  
+**Note: For RSA and ECP function replacement, the behavior is different. Refer to the [ECP internal header](https://github.com/ARMmbed/mbedtls/blob/development/library/ecp_internal_alt.h) for more information.**  
+
+Note: for more information about the configuration file, see [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md).
 
 Some hardware acceleration engines require an initial setup to be done on the platform, before they can work, such as enabling cache, or initializing the cryptographic engine. Such setup should be implemented in the function `mbedtls_platform_setup()` and terminated in the function `mbedtls_platform_teardown()`, as shown in the example in [this article](/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS.md).
 
@@ -26,7 +28,7 @@ There are few basic rules for supporting full module alternative implementation:
 
 ## Full module replacement example: AES
 
-In `config.h`:
+In `mbedtls_config.h`:
 
 - **Enable** the definition of `MBEDTLS_AES_ALT`.
 
@@ -41,11 +43,11 @@ Add a file (conventionally `aes_alt.c`) to your build:
 
 ## Function replacement: SHA-256 process
 
-In `config.h`:
+In `mbedtls_config.h`:
 
 - **Enable** the definition of `MBEDTLS_SHA256_PROCESS_ALT`.
 
 Add a file (conventionally `sha256_alt.c`) to your build:
 
 - **Implement** `mbedtls_internal_sha256_process`.
-- Implement `mbedtls_sha256_process` if you need it in legacy applications.
+- Mbed TLS 2.x only: Implement `mbedtls_sha256_process` if you need it in legacy applications.

--- a/kb/development/hw_acc_guidelines.md
+++ b/kb/development/hw_acc_guidelines.md
@@ -1,14 +1,14 @@
 # Alternative cryptography engines implementation
 
-As mentioned in the [Mbed TLS Abstraction layers article](/kb/generic/abstraction-layers.md), Mbed TLS supports alternative implementation for most of its cryptography modules. A common use case is for hardware accelerated cryptography engines. There are a couple of methods for alternative implementations: specific function replacement and full module replacement. The latter is the more common one.
+As mentioned in the [Mbed TLS Abstraction layers article](../generic/abstraction-layers.md), Mbed TLS supports alternative implementation for most of its cryptography modules. A common use case is for hardware accelerated cryptography engines. There are a couple of methods for alternative implementations: specific function replacement and full module replacement. The latter is the more common one.
 
 The [configuration file (`mbedtls_config.h`)](https://github.com/Mbed-TLS/mbedtls/blob/development/include/mbedtls/mbedtls_config.h) lists the cryptography modules, which you can replace with alternative implementation. An alternative implementation of a module is effectively a driver for a piece of cryptographic hardware. These are named `MBEDTLS_<MODULE NAME>_ALT`. In order to support an alternative implementation for a module, uncomment the corresponding `*_ALT` definition. Function replacement is based on the function name, upper-cased, with the suffix `_ALT`. To support a hardware entropy source, enable `MBEDTLS_ENTROPY_HARDWARE_ALT` in the configuration file.  
 
 **Note: For RSA and ECP function replacement, the behavior is different. Refer to the [ECP internal header](https://github.com/Mbed-TLS/mbedtls/blob/development/library/ecp_internal_alt.h) for more information.**  
 
-Note: for more information about the configuration file, see [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md).
+Note: for more information about the configuration file, see [How do I configure Mbed TLS](../compiling-and-building/how-do-i-configure-mbedtls.md).
 
-Some hardware acceleration engines require an initial setup to be done on the platform, before they can work, such as enabling cache, or initializing the cryptographic engine. Such setup should be implemented in the function `mbedtls_platform_setup()` and terminated in the function `mbedtls_platform_teardown()`, as shown in the example in [this article](/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS.md).
+Some hardware acceleration engines require an initial setup to be done on the platform, before they can work, such as enabling cache, or initializing the cryptographic engine. Such setup should be implemented in the function `mbedtls_platform_setup()` and terminated in the function `mbedtls_platform_teardown()`, as shown in the example in [this article](../how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS.md).
 
 ## Guidelines
 

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -315,7 +315,6 @@ Source files are structured as follows:
 #if !defined(MBEDTLS_AES_ALT)
 ```
 * Private local defines and portability code.
-* Static variables.
 * Function definitions.
 * If applicable, precompiler directive for marking the end of an alternative implementation:
 ```

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -259,7 +259,8 @@ Each module should keep loose coupling with external modules and functions in mi
 
 Structure header files as follows:
 
-* License Part (APACHE).
+* Brief description of the file.
+* Copyright notice and license indication.
 * Header file define for `MBEDTLS_ {MODULE_NAME} _H`:
 ```
 #ifndef MBEDTLS_AES_H
@@ -301,7 +302,8 @@ extern "C" {
 
 Source files are structured as follows:
 
-* License Part (APACHE).
+* Brief description of the file.
+* Copyright notice and license indication.
 * Comments on possible standard documents used.
 * Precompiler directive for module:
 ```

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -116,6 +116,8 @@ All public names (functions, variables, types, `enum` constants, macros) must st
     mbedtls_aes_setkey_decrypt()
 ```
 
+Exception: code implementing the PSA crypto API uses the `PSA_` and `psa_` prefixes. This includes official APIs as well as draft APIs that are on the PSA standards track. API extensions which are meant to remain specific to Mbed TLS, and internal functions, should use the `MBEDTLS_/mbedtls_` prefix, however there are many existing cases of using the `PSA_/psa_` prefix.
+
 ### Local names
 
 Static functions and macros that are not in public headers follow the same convention except the initial `MBEDTLS_` or `mbedtls_` prefix: they start directly with the function name.
@@ -127,6 +129,8 @@ Function parameters and local variables need no name spacing. They should use de
 By default all lengths and sizes are in bytes (or in number of elements, for arrays). If a name refers to a length or size in bits (as is often the case for key sizes) then the name must explicitly include `bit`, for example `mbedtls_pk_get_bitlen()` returns the size of the key in bits, while `mbedtls_pk_get_len()` returns the size in bytes. In addition, the documentation should always mention explicitly if key sizes are in bits or in bytes.
 
 ## API conventions
+
+This section applies fully to classic `mbedtls_xxx()` APIs and mostly to the newer `psa_xxx()` APIs. PSA have their own [conventions described in the PSA Crypto API specification](https://armmbed.github.io/mbed-crypto/html/overview/conventions.html) which take precedence in case of conflicts.
 
 ### Module contexts
 
@@ -148,6 +152,7 @@ Most functions should return `int`, more specifically `0` on success (the operat
 
 * Functions that can never fail should either return `void` (such as `mbedtls_cipher_init()`) or directly the information requested (such as `mbedtls_mpi_get_bit()`).
 * Functions that look up some information should return either a pointer to this information or `NULL` if it wasn't found.
+* PSA functions that can fail return a [`psa_status_t` value](https://armmbed.github.io/mbed-crypto/html/overview/conventions.html#return-status).
 * Some functions may multiplex the return value, such as `mbedtls_asn1_write_len()` returns the length written on success or a negative error code. This mimics the behavior of some standard functions such as `write()` and `read()`, except there is no equivalent to `errno`: the return code should be specific enough.
 * Some internal functions may return `-1` on errors rather than a specific error code; it is then up to the calling function to pick a more appropriate error code if the error is to be propagated back to the user.
 * Functions whose name clearly indicates a boolean (such as, the name contains "has", "is" or "can") should return `0` for false and `1` for true. The name must be clear: for example, `mbdtls_has_foobar_support()` will return `1` if support for foobar is present; by contrast, `mbedtls_check_foobar_support()` will return `0` if support for foobar is present (success) and `-1` or a more specific error code if not. All functions named `check` must follow this rule and return `0` to indicate acceptable/valid/present/etc. Preference should generally be given to `check` names in order to avoid a mixture of `== 0` and `!= 0` tests.
@@ -161,6 +166,9 @@ Function should avoid in-out parameters for length (multiplexing buffer size on 
     mbedtls_write_thing( void *thing, unsigned char *buf, size_t buflen,
                          size_t *outlen ); // yes
 ```
+
+For PSA functions, [input buffers](https://armmbed.github.io/mbed-crypto/html/overview/conventions.html#input-buffer-sizes) have a `size_t xxx_size` parameter after the buffer pointer, and [output buffers](https://armmbed.github.io/mbed-crypto/html/overview/conventions.html#output-buffer-sizes) have a `size_t xxx_size` parameter for the buffer size followed by a `size_t *xxx_length` parameter for the output length. This convention is also preferred in new `mbedtls_xxx` code, but older modules often use different conventions.
+
 You can use in-out parameters for functions that receive a pointer to some buffer, and update it after parsing from or writing to that buffer:
 ```
     mbedtls_asn1_get_int( unsigned char **p,

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -206,6 +206,8 @@ Use of `goto` is allowed in functions that have to do cleaning up before returni
 
 Structure functions to exit or `goto` the exit code as early as possible. This prevents nesting of code blocks and improves code readability.
 
+Most functions that need cleanup have a single cleanup block at the end. The label for this block can be `cleanup:` or `exit:` (or `error:` if the block is skipped on success); follow the established convention when extending an existing module. Code that uses bignum must use `cleanup:` for the sake of `MBEDTLS_MPI_CHK`.
+
 ### External function dependencies
 
 Mbed TLS code should minimize use of external functions. Standard `libc` functions are allowed, but should be documented in the [KB article on external dependencies](what-external-dependencies-does-mbedtls-rely-on.md).

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -204,7 +204,7 @@ Mbed TLS code should minimize use of external functions. Standard `libc` functio
 
 ### Minimize code based on precompiler directives
 
-To minimize the code size and external dependencies, the availability of modules and module functionality is controlled by precompiler directives located in `config.h`. Each module should have at least its own module define for enabling or disabling the module altogether. Other files using the module header should only include the header file if the module is actually available.
+To minimize the code size and external dependencies, the availability of modules and module functionality is controlled by precompiler directives located in `mbedtls/mbedtls_config.h`. Each module should have at least its own module define for enabling or disabling the module altogether. Other files using the module header should only include the header file if the module is actually available.
 
 Since often systems that use Mbed TLS do not have a file system, functions specifically using the file system should be contained in `MBEDTLS_FS_IO` directives.
 
@@ -303,25 +303,19 @@ Source files are structured as follows:
 
 * License Part (APACHE).
 * Comments on possible standard documents used.
-* Config include and precompiler directive for module:
+* Precompiler directive for module:
 ```
-#if !defined(MBEDTLS_CONFIG_FILE)
-#include "mbedtls/config.h"
-#else
-#include MBEDTLS_CONFIG_FILE
-#endif
-
 #if defined(MBEDTLS_AES_C)
 ```
-* Includes.
-* Precompiler directive for alternative implementation:
+* Includes. All library source files start by including `"common.h"`.
+* If applicable, precompiler directive for alternative implementation:
 ```
 #if !defined(MBEDTLS_AES_ALT)
 ```
 * Private local defines and portability code.
 * Static variables.
 * Function definitions.
-* Precompiler directive for marking the end of an alternative implementation:
+* If applicable, precompiler directive for marking the end of an alternative implementation:
 ```
 #endif /* !MBEDTLS_AES_ALT */
 ```

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -266,7 +266,7 @@ Structure header files as follows:
 #ifndef MBEDTLS_AES_H
 #define MBEDTLS_AES_H
 ```
-* Includes.
+* Includes. Always include `<mbedtls/build_info.h>` before anything that might depend on the compile-time configuration.
 * Public defines (Generic and error codes) and portability code.
 * C++ wrapper for C code:
 ```

--- a/kb/development/restartable-ecc.md
+++ b/kb/development/restartable-ecc.md
@@ -6,7 +6,7 @@ Continue reading to learn about the workflow of the restartable ECC feature, sta
 
 ## Enabling the restartable ECC feature, generic flow
 
-* At configuration time, define `MBEDTLS_ECP_RESTARTABLE` in `mbedtls/mbedtls_config.h`. See [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md) for more information.
+* At configuration time, define `MBEDTLS_ECP_RESTARTABLE` in `mbedtls/mbedtls_config.h`. See [How do I configure Mbed TLS](../compiling-and-building/how-do-i-configure-mbedtls.md) for more information.
 * Set the maximal number of operations that you want to run in a row with the `ECP` module, using `mbedtls_ecp_set_max_ops()`.
 * Allocate the restart context, and initialize it by calling `mbedtls_xxx_restart_init()`.
 * `ECP`, `ECDSA`, `PK` and `X.509` need an explicit restart context, and `ECDH` and `SSL` don't, though `ECDH` requires an additional call to `mbedtls_ecdh_enable_restart()`.

--- a/kb/development/restartable-ecc.md
+++ b/kb/development/restartable-ecc.md
@@ -1,12 +1,12 @@
 # Nonblocking ECC
 
-ECC operations are expensive. They're the most expensive operations in a typical TLS handshake, which includes many of them. On small boards, for example, based on a Cortex M0 core, a TLS handshake can spend several seconds on ECC operations. In a threaded environment, such as Mbed OS, this is not a problem because other threads can execute concurrently. In nonthreaded environments, blocking for several seconds on an operation is not acceptable if the system needs to attend to other tasks in a timely fashion. In order to support that case, Mbed TLS provides a restartable version of `ECC` operations, and all operations that depend on them (such as TLS handshakes), through the configuration option `MBEDTLS_ECP_RESTARTABLE` in *config.h*. Restartable functions enable collaborative multitasking by returning after a configurable amount of computations, so that you can attend to other tasks. They then continue the operation, and so on, until it completes. The `ECP`, `ECDSA`, `ECDH`, `PK`, `X.509` and `SSL` modules support this feature. Curve25519 does not support this feature at this time.
+ECC operations are expensive. They're the most expensive operations in a typical TLS handshake, which includes many of them. On small boards, for example, based on a Cortex M0 core, a TLS handshake can spend several seconds on ECC operations. In a threaded environment, such as Mbed OS, this is not a problem because other threads can execute concurrently. In nonthreaded environments, blocking for several seconds on an operation is not acceptable if the system needs to attend to other tasks in a timely fashion. In order to support that case, Mbed TLS provides a restartable version of `ECC` operations, and all operations that depend on them (such as TLS handshakes), through the configuration option `MBEDTLS_ECP_RESTARTABLE` in the configuration header (`mbedtls/mbedtls_config.h`). Restartable functions enable collaborative multitasking by returning after a configurable amount of computations, so that you can attend to other tasks. They then continue the operation, and so on, until it completes. The `ECP`, `ECDSA`, `ECDH`, `PK`, `X.509` and `SSL` modules support this feature. Curve25519 does not support this feature at this time.
 
 Continue reading to learn about the workflow of the restartable ECC feature, starting with the broad concept followed by specific examples.
 
 ## Enabling the restartable ECC feature, generic flow
 
-* At configuration time, define `MBEDTLS_ECP_RESTARTABLE` in *config.h*.
+* At configuration time, define `MBEDTLS_ECP_RESTARTABLE` in `mbedtls/mbedtls_config.h`. See [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md) for more information.
 * Set the maximal number of operations that you want to run in a row with the `ECP` module, using `mbedtls_ecp_set_max_ops()`.
 * Allocate the restart context, and initialize it by calling `mbedtls_xxx_restart_init()`.
 * `ECP`, `ECDSA`, `PK` and `X.509` need an explicit restart context, and `ECDH` and `SSL` don't, though `ECDH` requires an additional call to `mbedtls_ecdh_enable_restart()`.
@@ -176,7 +176,7 @@ For example:
 
 The restartable feature is done automatically, as long as:
 
-1. You define `MBEDTLS_ECP_RESTARTABLE` in *config.h*.
+1. You define `MBEDTLS_ECP_RESTARTABLE` in `mbedtls/mbedtls_config.h`.
 1. The TLS protocol is TLS 1.2 and higher.
 1. The negotiated key exchange is `MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA`.
 1. You call `mbedtls_ecp_set_max_ops()`.

--- a/kb/development/sample_applications.md
+++ b/kb/development/sample_applications.md
@@ -2,7 +2,7 @@
 
 Mbed TLS supplies several sample applications that demonstrate common use cases of the API. **These are sample programs only and do not cover full functionality of the API, or all use cases!**
 
-These examples are in the [*programs*](https://github.com/ARMmbed/mbedtls/tree/development/programs) folder, separated into subfolders according to their theme.  
+These examples are in the [*programs*](https://github.com/Mbed-TLS/mbedtls/tree/development/programs) folder, separated into subfolders according to their theme.  
 
 For more information, check the applications' `usage`.
 
@@ -33,12 +33,12 @@ These sample applications demonstrate the usage of asymmetric cryptography APIs 
 - `key_app_writer` - An example that demonstrates how to write a key file in different formats (`PEM` and `DER`), from a given key.
 - `key_app` - A program demonstrating how to read and parse a key.
 - `mpi_demo` - An application demonstrating how to use the multiple precision integers (`mpi`) APIs.
-- `pk_decrypt` - A reference application that demonstrates how to use the Public key-based decryption, using the [`pk`](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/pk.h) wrapper APIs.
-- `pk_encrypt` - A reference application that demonstrates how to use the Public key-based encryption, using the [`pk`](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/pk.h) wrapper APIs.
-- `pk_sign` - A reference application that demonstrates how to use the Public key-based signature creation, using the [`pk`](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/pk.h) wrapper APIs.
-- `pk_verify` - A reference application that demonstrates how to use the Public key-based signature verification, using the [`pk`](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/pk.h) wrapper APIs.
-- `rsa_decrypt` - An RSA decryption reference program, using the [`rsa`](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/rsa.h) APIs.
-- `rsa_encrypt` - An RSA encryption reference program, using the [`rsa`](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/rsa.h) APIs.
+- `pk_decrypt` - A reference application that demonstrates how to use the Public key-based decryption, using the [`pk`](https://github.com/Mbed-TLS/mbedtls/blob/development/include/mbedtls/pk.h) wrapper APIs.
+- `pk_encrypt` - A reference application that demonstrates how to use the Public key-based encryption, using the [`pk`](https://github.com/Mbed-TLS/mbedtls/blob/development/include/mbedtls/pk.h) wrapper APIs.
+- `pk_sign` - A reference application that demonstrates how to use the Public key-based signature creation, using the [`pk`](https://github.com/Mbed-TLS/mbedtls/blob/development/include/mbedtls/pk.h) wrapper APIs.
+- `pk_verify` - A reference application that demonstrates how to use the Public key-based signature verification, using the [`pk`](https://github.com/Mbed-TLS/mbedtls/blob/development/include/mbedtls/pk.h) wrapper APIs.
+- `rsa_decrypt` - An RSA decryption reference program, using the [`rsa`](https://github.com/Mbed-TLS/mbedtls/blob/development/include/mbedtls/rsa.h) APIs.
+- `rsa_encrypt` - An RSA encryption reference program, using the [`rsa`](https://github.com/Mbed-TLS/mbedtls/blob/development/include/mbedtls/rsa.h) APIs.
 - `rsa_genkey` - An application demonstrating how to generate an RSA key pair.
 - `rsa_sign_pss` - An application demonstrating how to create a signature with the [PKCS #1 v2.1](https://www.ietf.org/rfc/rfc3447.txt) padding scheme.
 - `rsa_sign` - An application demonstrating how create a signature with the [PKCS #1 v1.5](https://tools.ietf.org/html/rfc2313) padding scheme.
@@ -57,7 +57,7 @@ These applications demonstrate how to use Mbed TLS TRNG and PRNG APIs.
 
 These applications demonstrate common use cases for the SSL\TLS stack APIs.  
 
-**Note: These applications use the [Mbed TLS test root certificate](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/certs.h) and are meant to work with one another. To test the client applications with an external server, the root certificate needs to be set correctly by calling the [`mbedtls_ssl_conf_ca_chain()`](/api/ssl_8h.html#a85c3bb6b682ba361d13de1c0a1eb69fb). Alternatively, some applications allow to optionally set the CA root certificate file through the command-line. To test the server applications with external clients, they need to replace `mbedtls_x509_crt_parse()` with [`mbedtls_x509_crt_parse_file()`](/api/group__x509__module.html#gad4da63133d3590aa311488497d4c38ec) to read the server and CA certificates, as well as replacing `mbedtls_pk_parse_key()` with [`mbedtls_pk_parse_keyfile()`](/api/pk_8h.html#a935d710e542409462d0209f2381da83e).**
+**Note: These applications use the [Mbed TLS test root certificate](https://github.com/Mbed-TLS/mbedtls/blob/development/include/mbedtls/certs.h) and are meant to work with one another. To test the client applications with an external server, the root certificate needs to be set correctly by calling the [`mbedtls_ssl_conf_ca_chain()`](/api/ssl_8h.html#a85c3bb6b682ba361d13de1c0a1eb69fb). Alternatively, some applications allow to optionally set the CA root certificate file through the command-line. To test the server applications with external clients, they need to replace `mbedtls_x509_crt_parse()` with [`mbedtls_x509_crt_parse_file()`](/api/group__x509__module.html#gad4da63133d3590aa311488497d4c38ec) to read the server and CA certificates, as well as replacing `mbedtls_pk_parse_key()` with [`mbedtls_pk_parse_keyfile()`](/api/pk_8h.html#a935d710e542409462d0209f2381da83e).**
 
 - `dtls_client` - A DTLS client demonstration program.
 - `dtls_server` - A DTLS server demonstration program.

--- a/kb/development/test_suites.md
+++ b/kb/development/test_suites.md
@@ -13,7 +13,7 @@ A test data file consists of a sequence of paragraphs separated by a single empt
 Each paragraph describes one test case and must consist of:
 
 1. One line, which is the test case name.
-1. An optional line starting with the 11-character prefix `depends_on:`. This line consists of a list of compile-time options separated by the character ':', with no whitespace. The test case is executed only if all of these configuration options are enabled in `config.h`. Note that this filtering is done at run time.
+1. An optional line starting with the 11-character prefix `depends_on:`. This line consists of a list of compile-time options separated by the character ':', with no whitespace. The test case is executed only if all of these configuration options are enabled in `mbedtls_config.h`. Note that this filtering is done at run time.
 1. A line containing the test case function to execute and its parameters. This last line contains a test function name and a list of parameters separated by the character ':'. Each parameter can be any C expression of the correct type (only `int` or `char *` are allowed as parameters).
 
 For example:
@@ -29,13 +29,13 @@ pk_parse_keyfile_rsa:"data_files/keyfile.aes256":"testkey":0
 Code file that contains the actual test functions. The file contains a series of code sequences that the following delimit:
 
 * `BEGIN_HEADER` / `END_HEADER` - Code that will be added to the header of the generated `.c` file. It could contain include directives, global variables, type definitions and static functions.
-* `BEGIN_DEPENDENCIES` / `END_DEPENDENCIES` - A list of configuration options that this test suite depends on. The test suite will only be generated if all of these options are enabled in `config.h`.
+* `BEGIN_DEPENDENCIES` / `END_DEPENDENCIES` - A list of configuration options that this test suite depends on. The test suite will only be generated if all of these options are enabled in `mbedtls_config.h`.
 * `BEGIN_SUITE_HELPERS` / `END_SUITE_HELPERS` - Similar to `XXXX_HEADER` sequence, except that this code will be added after the header sequence, in the generated `.c` file.
 * `BEGIN_CASE` / `END_CASE` - The test case functions in the test suite. Between each of these pairs, you should write *exactly* one function that is used to create the dispatch code. Between the `BEGIN_CASE` directive and the function definition, you shouldn't add anything, not even a comment.
 
-An optional addition `depends_on:` has same usage as in the `.data` files. The section with this annotation will only be generated if all of the specified options are enabled in `config.h`. It can be added to the following delimiters:
+An optional addition `depends_on:` has same usage as in the `.data` files. The section with this annotation will only be generated if all of the specified options are enabled in `mbedtls_config.h`. It can be added to the following delimiters:
 
-* `BEGIN_DEPENDENCIES` - When added in this delimiter section, the whole test suite will be generated only if all the configuration options are defined in `config.h`.
+* `BEGIN_DEPENDENCIES` - When added in this delimiter section, the whole test suite will be generated only if all the configuration options are defined in `mbedtls_config.h`.
 
     For example:
     ```
@@ -45,7 +45,7 @@ An optional addition `depends_on:` has same usage as in the `.data` files. The s
      */
     ```
 
-* `BEGIN_CASE` - When added to this delimiter, this specific test case will be generated at compile time only if the configuration option is defined in `config.h`.
+* `BEGIN_CASE` - When added to this delimiter, this specific test case will be generated at compile time only if the configuration option is defined in `mbedtls_config.h`.
 
     For example:
     ```

--- a/kb/development/test_suites.md
+++ b/kb/development/test_suites.md
@@ -54,7 +54,7 @@ An optional addition `depends_on:` has same usage as in the `.data` files. The s
 
 ## `helpers.function` file
 
-This file, as its name indicates, contains useful common helper functions that can be used in the test functions. There are several functions, which are described in [`helpers.function`](https://github.com/ARMmbed/mbedtls/blob/development/tests/suites/helpers.function) itself. Following are a few common functions:
+This file, as its name indicates, contains useful common helper functions that can be used in the test functions. There are several functions, which are described in [`helpers.function`](https://github.com/Mbed-TLS/mbedtls/blob/development/tests/suites/helpers.function) itself. Following are a few common functions:
 
 * `hexify()` - A function converting binary data into a null-terminated string. You can be use it to convert a binary output to a string buffer, to be compared with expected output given as a string parameter.
 * `unhexify()` - A function converting a null-terminated string buffer into a binary buffer, returning the length of the data in the buffer. You can use it to convert the input string parameters to binary output for the function you are calling.
@@ -63,7 +63,7 @@ This file, as its name indicates, contains useful common helper functions that c
 
 ## Building your test suites
 
-The test suite `.c` files are auto generated with the `generate_code.pl` script. You could either use this script directly, or run `make` in the `tests/` folder, as the [`Makefile`](https://github.com/ARMmbed/mbedtls/blob/development/tests/Makefile) utilizes this script. Once the `.c` files are generated, you could build the test suite executables running `make` again. Running `make` from the Mbed TLS root folder will also generate the test suite source code, and build the test suite executables.
+The test suite `.c` files are auto generated with the `generate_code.pl` script. You could either use this script directly, or run `make` in the `tests/` folder, as the [`Makefile`](https://github.com/Mbed-TLS/mbedtls/blob/development/tests/Makefile) utilizes this script. Once the `.c` files are generated, you could build the test suite executables running `make` again. Running `make` from the Mbed TLS root folder will also generate the test suite source code, and build the test suite executables.
 
 ## Introducing new tests
 
@@ -72,7 +72,7 @@ When you want to introduce a new test, if the test function:
 * Already exists and it only missing the test data, then update the .data file with the additional test data. If required, you can add a resource file to the `data_files/` subfolder.
 * Doesn't exist, you can implement a new test function in the relevant `.function` file following the guidelines mentioned above and add test cases to the .data file to test your new feature.
 
-If you need to define a new test suite, for example when you introduce a new cryptography module, update the [`Makefile`](https://github.com/ARMmbed/mbedtls/blob/development/tests/Makefile) to build your test suite.
+If you need to define a new test suite, for example when you introduce a new cryptography module, update the [`Makefile`](https://github.com/Mbed-TLS/mbedtls/blob/development/tests/Makefile) to build your test suite.
 
 You should write your test code in the same platform abstraction as the library, and should not assume the existence of platform-specific functions.
 

--- a/kb/development/thread-safety-and-multi-threading.md
+++ b/kb/development/thread-safety-and-multi-threading.md
@@ -11,6 +11,8 @@ The default philosophy is that a single thread should only use or access one con
 - The documentation for the functions that access the shared context explicitly states the function is thread-safe, or
 - You perform explicit locking yourself (perhaps in a wrapper function).
 
+**Warning: In Mbed TLS 2.x, and in Mbed TLS 3.x at the time of writing, [the PSA API is not thread-safe](https://github.com/Mbed-TLS/mbedtls/issues/3263).**
+
 ## Thread safety with different versions
 
 Mbed TLS has a generic threading layer that handles default locks and mutexes for the user and abstracts the threading layer to allow easy pluging in any thread-library.

--- a/kb/development/thread-safety-and-multi-threading.md
+++ b/kb/development/thread-safety-and-multi-threading.md
@@ -17,7 +17,7 @@ The default philosophy is that a single thread should only use or access one con
 
 Mbed TLS has a generic threading layer that handles default locks and mutexes for the user and abstracts the threading layer to allow easy pluging in any thread-library.
 
-Defining **MBEDTLS_THREADING_C** in `mbedtls_config.h` enables this threading layer. Please see [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md) for more information. It is not enabled by default; you also need to pick an underlying threading library. We provide built-in support for `pthread` with **MBEDTS_THREADING_PTHREAD**. You can also plug any other thread-library with **MBEDTLS_THREADING_ALT** and call `mbedtls_threading_set_alt()` at the beginning of your program and `mbedtls_threading_free_alt()` at the end.
+Defining **MBEDTLS_THREADING_C** in `mbedtls_config.h` enables this threading layer. Please see [How do I configure Mbed TLS](../compiling-and-building/how-do-i-configure-mbedtls.md) for more information. It is not enabled by default; you also need to pick an underlying threading library. We provide built-in support for `pthread` with **MBEDTS_THREADING_PTHREAD**. You can also plug any other thread-library with **MBEDTLS_THREADING_ALT** and call `mbedtls_threading_set_alt()` at the beginning of your program and `mbedtls_threading_free_alt()` at the end.
 
 ## Status of various contexts and associated functions
 

--- a/kb/development/thread-safety-and-multi-threading.md
+++ b/kb/development/thread-safety-and-multi-threading.md
@@ -15,7 +15,7 @@ The default philosophy is that a single thread should only use or access one con
 
 Mbed TLS has a generic threading layer that handles default locks and mutexes for the user and abstracts the threading layer to allow easy pluging in any thread-library.
 
-Defining **MBEDTLS_THREADING_C** in *config.h* enables this threading layer. Please see [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md) for more information. It is not enabled by default; you also need to pick an underlying threading library. We provide built-in support for `pthread` with **MBEDTS_THREADING_PTHREAD**. You can also plug any other thread-library with **MBEDTLS_THREADING_ALT** and call `mbedtls_threading_set_alt()` at the beginning of your program and `mbedtls_threading_free_alt()` at the end.
+Defining **MBEDTLS_THREADING_C** in `mbedtls_config.h` enables this threading layer. Please see [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md) for more information. It is not enabled by default; you also need to pick an underlying threading library. We provide built-in support for `pthread` with **MBEDTS_THREADING_PTHREAD**. You can also plug any other thread-library with **MBEDTLS_THREADING_ALT** and call `mbedtls_threading_set_alt()` at the beginning of your program and `mbedtls_threading_free_alt()` at the end.
 
 ## Status of various contexts and associated functions
 

--- a/kb/development/what-external-dependencies-does-mbedtls-rely-on.md
+++ b/kb/development/what-external-dependencies-does-mbedtls-rely-on.md
@@ -53,7 +53,7 @@ The *Timing* module may also use `gettimeofday()` if it doesn't know how to acce
 
 **Functions covered:** `gettimeofday()`
 
-The `time()` function is abstracted as `mbedtls_time()`, in case `MBEDTLS_HAVE_TIME` is defined, and no alternative implementation was given with the definition of `MBEDTLS_PLATFORM_TIME_ALT` or no `MBEDTLS_PLATFORM_TIME_MACRO` was set. The `mbedtls_timetime()` function will be used by the *TLS core* modules, as well as the provided implementation of the following callbacks: SSL session cache, SSL session tickets, DTLS hello cookies. All these modules only rely on time differences. In other words, they do not need `time()` to return the correct time, much less the correct date. You can remove this dependency by disabling `MBEDTLS_HAVE_TIME` in the `config.h` file, but you may loose some features, such as time-based rotation of session ticket keys. Alternatively, you can supply a different implementation for `mbedtls_time()`, by defining `MBEDTLS_PLATFORM_TIME_ALT()` and call `mbedtls_platform_set_time()` to set your own time function.
+The `time()` function is abstracted as `mbedtls_time()`, in case `MBEDTLS_HAVE_TIME` is defined, and no alternative implementation was given with the definition of `MBEDTLS_PLATFORM_TIME_ALT` or no `MBEDTLS_PLATFORM_TIME_MACRO` was set. The `mbedtls_timetime()` function will be used by the *TLS core* modules, as well as the provided implementation of the following callbacks: SSL session cache, SSL session tickets, DTLS hello cookies. All these modules only rely on time differences. In other words, they do not need `time()` to return the correct time, much less the correct date. You can remove this dependency by disabling `MBEDTLS_HAVE_TIME` in the `mbedtls_config.h` file, but you may loose some features, such as time-based rotation of session ticket keys. Alternatively, you can supply a different implementation for `mbedtls_time()`, by defining `MBEDTLS_PLATFORM_TIME_ALT()` and call `mbedtls_platform_set_time()` to set your own time function.
 
 If your platform supports a time function, with a different name, but same functionality, you can set it as `MBEDTLS_PLATFORM_TIME_MACRO` (with a possibility of defining `MBEDTLS_PLATFORM_TIME_TYPE_MACRO` as well).
 
@@ -78,7 +78,7 @@ If `MBEDTLS_FS_IO` is defined, the file functions are used in several Mbed TLS m
 - The entropy, *CTR-DRBG* and *HMAC_DRBG* modules use file functions for reading and updating seed files.
 - The *DHM* module uses file operations to read DH parameters files (`mbedtls_dhm_parse_dhmfile`).
 
-You can disable all by commenting `MBEDTLS_FS_IO` in `config.h`.
+You can disable all by commenting `MBEDTLS_FS_IO` in `mbedtls_config.h`.
 
 **Functions covered:** 
 
@@ -119,7 +119,7 @@ The `memmove()` function is used as an optimization in the *TLS* module. It is a
 
 ## String functions
 
-The `printf()` function is used in all self test functions as `mbedtls_printf()`, controlled by the `MBEDTLS_SELF_TEST` configuration flags. In addition, in the *MPI* module (`bignum.c`), `mbedtls_mpi_write_file()` uses `mbedtls_printf()` to print to `stdout` if `MBEDTLS_FS_IO` is defined. You can disable these dependencies in the `config.h` file. You can also provide your own implementation through the platform layer, see `MBEDTLS_PLATFORM_PRINTF_ALT` for an example. If your platform supports a print function with a different name, you can set it as `MBEDTLS_PLATFORM_PRINTF_MACRO`.
+The `printf()` function is used in all self test functions as `mbedtls_printf()`, controlled by the `MBEDTLS_SELF_TEST` configuration flags. In addition, in the *MPI* module (`bignum.c`), `mbedtls_mpi_write_file()` uses `mbedtls_printf()` to print to `stdout` if `MBEDTLS_FS_IO` is defined. You can disable these dependencies in the `mbedtls_config.h` file. You can also provide your own implementation through the platform layer, see `MBEDTLS_PLATFORM_PRINTF_ALT` for an example. If your platform supports a print function with a different name, you can set it as `MBEDTLS_PLATFORM_PRINTF_MACRO`.
 
 **Functions covered:** `printf()`
 

--- a/kb/development/what-external-dependencies-does-mbedtls-rely-on.md
+++ b/kb/development/what-external-dependencies-does-mbedtls-rely-on.md
@@ -4,7 +4,7 @@
 
 Mbed TLS is as loosely coupled as possible and does not rely on any external libraries for its code. It does use a number of standard `libc` function calls. This page describes which external calls are present and how you can remove them if no support for that function is available; it focuses on the core library only (excluding the example programs and test suites, but including the self test functions as they are part of the library).
 
-Configuration flags control some of the dependencies. Please see [How do I configure mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md) and [How do I port Mbed TLS to a new environment or OS](/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS.md) for a full description of how to set the configuration flags to port Mbed TLS to a new environment.
+Configuration flags control some of the dependencies. Please see [How do I configure mbed TLS](../compiling-and-building/how-do-i-configure-mbedtls.md) and [How do I port Mbed TLS to a new environment or OS](../how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS.md) for a full description of how to set the configuration flags to port Mbed TLS to a new environment.
 
 ## Signals and alarms
 
@@ -24,7 +24,7 @@ Only `net_sockets.c` uses `select()`, for the purposes of sleeping (only used in
 
 ## Network/socket based functions
 
-The network and socket based functions are only used in the *Network* module (`net_sockets.c`). As the TLS part only uses function pointers, you can replace these dependencies with something else (such as lwIP) as long as the behavior is similar. To use different networking functions, disable `MBEDTLS_NET_C`, and implement your own socket module, as described in [the porting article](/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS.md).
+The network and socket based functions are only used in the *Network* module (`net_sockets.c`). As the TLS part only uses function pointers, you can replace these dependencies with something else (such as lwIP) as long as the behavior is similar. To use different networking functions, disable `MBEDTLS_NET_C`, and implement your own socket module, as described in [the porting article](../how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS.md).
 
 **Functions covered:** on Windows, functions from the Windows Sockets API, and on Unix:
 
@@ -96,7 +96,7 @@ You can disable all by commenting `MBEDTLS_FS_IO` in `mbedtls_config.h`.
 
 ## Dynamic memory functions
 
-A number of modules (ASN1, Bignum/MPI, Cipher, CMAC, DHM, ECP, MD, PEM, PK, PKCS11, RSA, TLS, X.509) use dynamic memory allocation. You can provide your own implementations, and we even provide a buffer-based memory allocator. For further details, read [Letting Mbed TLS use static memory instead of the heap](/kb/how-to/using-static-memory-instead-of-the-heap.md).
+A number of modules (ASN1, Bignum/MPI, Cipher, CMAC, DHM, ECP, MD, PEM, PK, PKCS11, RSA, TLS, X.509) use dynamic memory allocation. You can provide your own implementations, and we even provide a buffer-based memory allocator. For further details, read [Letting Mbed TLS use static memory instead of the heap](../how-to/using-static-memory-instead-of-the-heap.md).
 
 **Functions covered:** 
 

--- a/kb/generic/abstraction-layers.md
+++ b/kb/generic/abstraction-layers.md
@@ -12,9 +12,9 @@ These are standard functions from libc that are always needed. However, they wil
 
 Examples: `calloc()`, `free()`, `printf()` and `fprintf()`.
 
-These standard functions are abstracted in the **platform layer**. The layer core is enabled by default in `config.h` with `MBEDTLS_PLATFORM_C`, and allows the runtime customization of the relevant function.
+These standard functions are abstracted in the **platform layer**. The layer core is enabled by default in `mbedtls_config.h` with `MBEDTLS_PLATFORM_C`, and allows the runtime customization of the relevant function.
 
-The `MBEDTLS_PLATFORM_XXX` defined in `config.h` enables support for abstracting different functions.
+The `MBEDTLS_PLATFORM_XXX` defined in `mbedtls_config.h` enables support for abstracting different functions.
 
 For example, after enabling `MBEDTLS_PLATFORM_PRINTF_ALT`, you can set an alternative for `printf()` by calling `mbedtls_platform_set_printf()`.
 
@@ -24,7 +24,7 @@ These are additional functions from external libraries or OS that are needed onl
 
 Examples: threading.
 
-These abstractions are implemented in their own module and enabled or disabled with a single define, for example, `MBEDTLS_THREADING_C` in `config.h*`. They may also require additional configuration options. The threading library, for example, requires you to indicate which threading library you are using: pthread or an alternative.
+These abstractions are implemented in their own module and enabled or disabled with a single define, for example, `MBEDTLS_THREADING_C` in `mbedtls_config.h`. They may also require additional configuration options. The threading library, for example, requires you to indicate which threading library you are using: pthread or an alternative.
 
 ## Implementation abstraction
 
@@ -33,7 +33,7 @@ These are abstractions for functions that we already provide an implementation f
 Examples: AES, MD5 and Timing.
 
 To enable an implementation abstraction:
-- You'll need to enable the relevant macro: `MBEDTLS_XXX_ALT` in `config.h`.
+- You'll need to enable the relevant macro: `MBEDTLS_XXX_ALT` in `mbedtls_config.h`.
 - Provide a custom header, named: `xxx_alt.h`.
 - Provide an implementation.
 

--- a/kb/generic/what-tests-and-checks-are-run-for-polarssl.md
+++ b/kb/generic/what-tests-and-checks-are-run-for-polarssl.md
@@ -45,7 +45,7 @@ AES-256-ECB Decrypt NIST KAT #12 .................................. PASS
 PASSED (77 / 77 tests (0 skipped))
 ```
 
-More information on the test suites and how to add more tests can be found in [this article](/kb/development/test_suites.md).
+More information on the test suites and how to add more tests can be found in [this article](../development/test_suites.md).
 
 ### Interoperability testing
 Because our test vectors can only test individual functions, we also run interoperability tests to check live SSL connections against OpenSSL and GnuTLS.

--- a/kb/generic/what-tests-and-checks-are-run-for-polarssl.md
+++ b/kb/generic/what-tests-and-checks-are-run-for-polarssl.md
@@ -24,7 +24,7 @@ Mbed TLS uses a Buildbot environment to run these tests on a number of different
 ### Test Framework
 Currently, there are over 6000 automated test vectors that run in the `tests/` directory when `make check` is run. In CMake, `make memcheck` runs these tests under Valgrind.
 
-We have our own test framework for running these tests, which combines generic test functions with specific test values. The build system generates parsing-test applications, such as `test_suite_aes.ecb`, and runs them with the different test case inputs available. The system remains aware of the current configuration from `config.h` and ensures that only relevant tests are run.
+We have our own test framework for running these tests, which combines generic test functions with specific test values. The build system generates parsing-test applications, such as `test_suite_aes.ecb`, and runs them with the different test case inputs available. The system remains aware of the current configuration from `mbedtls_config.h` and ensures that only relevant tests are run.
 
 A sample output for these tests looks like this:
 

--- a/kb/how-to/add-a-random-generator.md
+++ b/kb/how-to/add-a-random-generator.md
@@ -66,6 +66,6 @@ Another way to add entropy at the start of your application is to use a seed fil
 
 ## Multithreaded use
 
-If you intend to use the CTR-DRBG module in multiple threads, please read our article on [entropy collection, random generation with threads](/kb/development/entropy-collection-and-random-generation-in-threaded-environment.md).
+If you intend to use the CTR-DRBG module in multiple threads, please read our article on [entropy collection, random generation with threads](../development/entropy-collection-and-random-generation-in-threaded-environment.md).
 
 <!--- "add-a-random-generator","Short article on how to add a good random generator to your application. Complete with source code examples!",,"entropy, random data, random number generator, RNG, ctr-drbg, entropy pool, security",published,"2013-09-11 12:10:00",2,11128,"2017-04-24 11:16:00","Paul Bakker" --->

--- a/kb/how-to/code-size.md
+++ b/kb/how-to/code-size.md
@@ -8,7 +8,7 @@ Obtain the code size of the library by using the `arm-none-eabi-size -t` command
 
 Mbed TLS supplies a script that checks the [footprint](https://github.com/ARMmbed/mbedtls/blob/development/scripts/footprint.sh) of the library. The script shows the code size of the library compiled with several configuration files:
 
-* `include/mbedtls/config.h` - The default configuration file, unless modified by the user.
+* `include/mbedtls/mbedtls_config.h` (`include/mbedtls/config.h` in Mbed TLS 2.x) - The default configuration file, unless modified by the user.
 * `configs/config-thread.h` - A minimal configuration example of Mbed TLS using Thread networking protocol.
 * `configs/config-suite-b.h` - A minimal configuration example supporting NSA Suite B.
 * `configs/config-ccm-psk-tls1_2.h` - A minimal configuration example supporting preshared key and with AES-CCM.
@@ -18,7 +18,7 @@ Mbed TLS supplies a script that checks the [footprint](https://github.com/ARMmbe
 * `arm-none-eabi` toolchain installed and found in the `PATH` environment variable.
 * `make`.
 * POSIX shell.
-* Updated `include/mbedtls/config.h` with the required configuration.
+* Updated `include/mbedtls/mbedtls_config.h` with the required configuration. See [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md) for more information.
 
 Note: The `arm-none-eabi` toolchain may give different results than other toolchains, such as `ARMCC` or `IAR.
 

--- a/kb/how-to/code-size.md
+++ b/kb/how-to/code-size.md
@@ -6,7 +6,7 @@ Mbed TLS is a configurable library, so its code size varies, depending on the co
 
 Obtain the code size of the library by using the `arm-none-eabi-size -t` command (when using the `arm-none-eabi` toolchain).
 
-Mbed TLS supplies a script that checks the [footprint](https://github.com/ARMmbed/mbedtls/blob/development/scripts/footprint.sh) of the library. The script shows the code size of the library compiled with several configuration files:
+Mbed TLS supplies a script that checks the [footprint](https://github.com/Mbed-TLS/mbedtls/blob/development/scripts/footprint.sh) of the library. The script shows the code size of the library compiled with several configuration files:
 
 * `include/mbedtls/mbedtls_config.h` (`include/mbedtls/config.h` in Mbed TLS 2.x) - The default configuration file, unless modified by the user.
 * `configs/config-thread.h` - A minimal configuration example of Mbed TLS using Thread networking protocol.

--- a/kb/how-to/code-size.md
+++ b/kb/how-to/code-size.md
@@ -18,7 +18,7 @@ Mbed TLS supplies a script that checks the [footprint](https://github.com/Mbed-T
 * `arm-none-eabi` toolchain installed and found in the `PATH` environment variable.
 * `make`.
 * POSIX shell.
-* Updated `include/mbedtls/mbedtls_config.h` with the required configuration. See [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md) for more information.
+* Updated `include/mbedtls/mbedtls_config.h` with the required configuration. See [How do I configure Mbed TLS](../compiling-and-building/how-do-i-configure-mbedtls.md) for more information.
 
 Note: The `arm-none-eabi` toolchain may give different results than other toolchains, such as `ARMCC` or `IAR.
 

--- a/kb/how-to/controlling_package_size.md
+++ b/kb/how-to/controlling_package_size.md
@@ -30,7 +30,7 @@ mbedtls_ssl_set_mtu()
 This function may be called at any point during the lifetime of an SSL context, depending on when information about the underlying datagram link's MTU becomes available or gets updated (for example, when the rate of package loss indicates that your MTU configuration is too large). It takes effect immediately, ensuring that no datagram of a size exceeding the MTU is sent, and fragmenting handshake messages if necessary to guarantee this.
 
 
-For example, to set the initial MTU value used for the handshake, the function should be called after the SSL context has been set up using `mbedtls_ssl_setup()`, but before performing the handshake using `mbedtls_ssl_handshake()`. This is exemplified in the [ssl_server2](https://github.com/ARMmbed/mbedtls/blob/development/programs/ssl/ssl_server2.c) and [ssl_client2](https://github.com/ARMmbed/mbedtls/blob/development/programs/ssl/ssl_client2.c) example programs.
+For example, to set the initial MTU value used for the handshake, the function should be called after the SSL context has been set up using `mbedtls_ssl_setup()`, but before performing the handshake using `mbedtls_ssl_handshake()`. This is exemplified in the [ssl_server2](https://github.com/Mbed-TLS/mbedtls/blob/development/programs/ssl/ssl_server2.c) and [ssl_client2](https://github.com/Mbed-TLS/mbedtls/blob/development/programs/ssl/ssl_client2.c) example programs.
 
 ### Getting the maximum application data size
 

--- a/kb/how-to/dtls-tutorial.md
+++ b/kb/how-to/dtls-tutorial.md
@@ -104,6 +104,6 @@ The cookie callbacks that are registered by default always fail. The rationale i
 You can, **if you are sure that amplification attacks against third parties are not an issue** in your particular deployment, disable `ClientHello` verification at run-time:
 
 * Register `NULL` callbacks.
-* Alternatively, at compilation: Undefine **MBEDTLS_SSL_DTLS_HELLO_VERIFY** in `config.h`.
+* Alternatively, at compilation: Undefine **MBEDTLS_SSL_DTLS_HELLO_VERIFY** in `mbedtls_config.h`.
 
 <!---",dtls-tutorial,"Article on the DTLS implementation inside Mbed TLS",,"dtls, tutorial",published,"2015-07-24 08:51:00",2,17496,"2016-02-17 17:31:00","Manuel PÃgouriÃ-Gonnard"--->

--- a/kb/how-to/dtls-tutorial.md
+++ b/kb/how-to/dtls-tutorial.md
@@ -66,7 +66,7 @@ With event-based I/O, **don't** use read timeouts by calling `mbedtls_ssl_conf_r
 
 The retransmission delay starts with a minimum value, then doubles on each retransmission until its maximum value is reached, in which case a handshake timeout is reported to the application. The minimum and maximum can be set using `mbedtls_ssl_conf_handshake_timeout()` (default: 1 to 60 seconds).
 
-See [the documentation of this function](https://github.com/ARMmbed/mbedtls/blob/edb1a483971c836e84e95d7b73ee39bd6b450675/include/mbedtls/ssl.h#L1300) for the meaning of those values if you need to tune them according to the characteristics of your network in order to achieve optimal performance/reliability. Even if your timeout values are perfectly tuned, your application should still be prepared to see failing handshakes and react appropriately.
+See [the documentation of this function](https://github.com/Mbed-TLS/mbedtls/blob/edb1a483971c836e84e95d7b73ee39bd6b450675/include/mbedtls/ssl.h#L1300) for the meaning of those values if you need to tune them according to the characteristics of your network in order to achieve optimal performance/reliability. Even if your timeout values are perfectly tuned, your application should still be prepared to see failing handshakes and react appropriately.
 
 <span class="notes">**Note:**: There might seem to be a parallel between `mbedtls_ssl_conf_handshake_timeout()` and `set_delay()` as they both accept two durations as arguments, but this is not the case. The **final delay** will take various values from `min` to `max`, doubling every time, while the **intermediate delay** is an internal implementation detail.</span>
 

--- a/kb/how-to/encrypt-and-decrypt-with-rsa.md
+++ b/kb/how-to/encrypt-and-decrypt-with-rsa.md
@@ -4,9 +4,9 @@
 
 To perform RSA encryption or decryption, you will need an RSA key. In the case of an RSA-2048 decryption, you will need a **2048-bit RSA key**.
 
-More information on generating an RSA key pair is in our article on [RSA key pair generation](/kb/cryptography/rsa-key-pair-generator.md). For now, we assume you have **already generated one or already have one in your possession**.
+More information on generating an RSA key pair is in our article on [RSA key pair generation](../cryptography/rsa-key-pair-generator.md). For now, we assume you have **already generated one or already have one in your possession**.
 
-You can recognize a PEM formatted RSA key pair because it starts with a line with dashes around the string `BEGIN RSA PRIVATE KEY` or `BEGIN PRIVATE KEY`. In the case of the latter, it is not necessarily an RSA key, because `BEGIN PRIVATE KEY` is also used for Elliptic Curve and other types of keys. Information on the PEM formatted key structure can be found in [this article](/kb/cryptography/asn1-key-structures-in-der-and-pem.md).
+You can recognize a PEM formatted RSA key pair because it starts with a line with dashes around the string `BEGIN RSA PRIVATE KEY` or `BEGIN PRIVATE KEY`. In the case of the latter, it is not necessarily an RSA key, because `BEGIN PRIVATE KEY` is also used for Elliptic Curve and other types of keys. Information on the PEM formatted key structure can be found in [this article](../cryptography/asn1-key-structures-in-der-and-pem.md).
 
 You will need to start by [adding a random number generator (RNG)](add-a-random-generator.md) to your application. In this tutorial, the RNG is the CTR-DRBG generator, and the context is called `ctr_drbg`. The RSA public key is called `our-key.pub`, and the RSA private key is called `our-key.pem`.
 
@@ -41,7 +41,7 @@ Start by initializing the public key context and reading in the public key:
         goto exit;
     }
 ```
-<span class="notes">**Note:** There is a [maximum amount of data you can encrypt with RSA](/kb/cryptography/rsa-encryption-maximum-data-size.md). For a 2048 bit RSA key, the maximum you can encrypt is 245 bytes (or 1960 bits).</span>
+<span class="notes">**Note:** There is a [maximum amount of data you can encrypt with RSA](../cryptography/rsa-encryption-maximum-data-size.md). For a 2048 bit RSA key, the maximum you can encrypt is 245 bytes (or 1960 bits).</span>
 
 Store the data to be encrypted and its length in variables. This tutorial uses `to_encrypt` for the data, and its length in `to_encrypt_len`:
 ```

--- a/kb/how-to/generate-a-certificate-request-csr.md
+++ b/kb/how-to/generate-a-certificate-request-csr.md
@@ -30,7 +30,7 @@ This key generation application accepts the following arguments:
     filename=%s           default: keyfile.key
     format=pem|der        default: pem
 ```
-The following command generates a 2048 bit RSA key file, as explained [here](/kb/cryptography/rsa-key-pair-generator.md):
+The following command generates a 2048 bit RSA key file, as explained [here](../cryptography/rsa-key-pair-generator.md):
 ```
 programs/pkey/gen_key type=rsa rsa_keysize=2048 filename=example.com.key
 ```

--- a/kb/how-to/generate-a-self-signed-certificate.md
+++ b/kb/how-to/generate-a-self-signed-certificate.md
@@ -22,7 +22,7 @@ This key generation application accepts the following arguments:
     filename=%s           default: keyfile.key
     format=pem|der        default: pem
 ```
-The following command generates a 4096 bit RSA key file, as explained [here](/kb/cryptography/rsa-key-pair-generator.md):
+The following command generates a 4096 bit RSA key file, as explained [here](../cryptography/rsa-key-pair-generator.md):
 ```
 programs/pkey/gen_key type=rsa rsa_keysize=4096 filename=our_key.key
 ```

--- a/kb/how-to/generate-an-aes-key.md
+++ b/kb/how-to/generate-an-aes-key.md
@@ -9,7 +9,7 @@ If you need to generate your own AES key for encrypting data, you should use a g
 
 Mbed TLS includes the [CTR-DRBG module](/ctr-drbg-source-code) and an [Entropy Collection module](/entropy-source-code) to help you with making an AES key generator for your key.
 
-To use the AES generator, you need to have the modules enabled in the `config.h` files (`MBEDTLS_CTR_DRBG_C` and `MBEDTLS_ENTROPY_C`), see [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md).
+To use the AES generator, you need to have the modules enabled in the `mbedtls/config.h` files (`MBEDTLS_CTR_DRBG_C` and `MBEDTLS_ENTROPY_C`), see [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md).
 
 Include the following headers in your code:
 

--- a/kb/how-to/generate-an-aes-key.md
+++ b/kb/how-to/generate-an-aes-key.md
@@ -9,7 +9,7 @@ If you need to generate your own AES key for encrypting data, you should use a g
 
 Mbed TLS includes the [CTR-DRBG module](/ctr-drbg-source-code) and an [Entropy Collection module](/entropy-source-code) to help you with making an AES key generator for your key.
 
-To use the AES generator, you need to have the modules enabled in the `mbedtls/config.h` files (`MBEDTLS_CTR_DRBG_C` and `MBEDTLS_ENTROPY_C`), see [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md).
+To use the AES generator, you need to have the modules enabled in the `mbedtls/config.h` files (`MBEDTLS_CTR_DRBG_C` and `MBEDTLS_ENTROPY_C`), see [How do I configure Mbed TLS](../compiling-and-building/how-do-i-configure-mbedtls.md).
 
 Include the following headers in your code:
 

--- a/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS.md
+++ b/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS.md
@@ -21,7 +21,7 @@ The only parts of the library that potentially interact with the environment are
 
 In short, in order to compile Mbed TLS for a bare-metal environment which already has a standard C library, [configure your build](/kb/compiling-and-building/how-do-i-configure-mbedtls.md) by disabling `MBEDTLS_NET_C`, `MBEDTLS_TIMING_C` and `MBEDTLS_ENTROPY_PLATFORM`, and potentially `MBEDTLS_FS_IO`, `MBEDTLS_HAVE_TIME_DATE` and `MBEDTLS_HAVE_TIME`.
 
-This is more thoroughly documented in [`config.h`](/api/config_8h.html).
+This is more thoroughly documented in [`mbedtls_config.h`](/api/config_8h.html).
 
 The following sections give more detail on how to replace the missing parts.
 

--- a/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS.md
+++ b/kb/how-to/how-do-i-port-mbed-tls-to-a-new-environment-OS.md
@@ -8,7 +8,7 @@ This page explains how to port Mbed TLS to a new environment.
 
 ## Overview
 
-Mbed TLS has a modular design. Many of the modules are completely independent of any runtime, environment, or other module dependencies, with the exception of [those dependent on the C library](/kb/development/what-external-dependencies-does-mbedtls-rely-on.md).
+Mbed TLS has a modular design. Many of the modules are completely independent of any runtime, environment, or other module dependencies, with the exception of [those dependent on the C library](../development/what-external-dependencies-does-mbedtls-rely-on.md).
 
 The only parts of the library that potentially interact with the environment are:
 
@@ -19,7 +19,7 @@ The only parts of the library that potentially interact with the environment are
 * Functions that need the current time from a real-time clock. You can disable them, although that limits what validation is possible for certificates.
 * Functions that print messages, generally used for debug and diagnosis. You can disable or replace them to output messages to another platform-specific debug.
 
-In short, in order to compile Mbed TLS for a bare-metal environment which already has a standard C library, [configure your build](/kb/compiling-and-building/how-do-i-configure-mbedtls.md) by disabling `MBEDTLS_NET_C`, `MBEDTLS_TIMING_C` and `MBEDTLS_ENTROPY_PLATFORM`, and potentially `MBEDTLS_FS_IO`, `MBEDTLS_HAVE_TIME_DATE` and `MBEDTLS_HAVE_TIME`.
+In short, in order to compile Mbed TLS for a bare-metal environment which already has a standard C library, [configure your build](../compiling-and-building/how-do-i-configure-mbedtls.md) by disabling `MBEDTLS_NET_C`, `MBEDTLS_TIMING_C` and `MBEDTLS_ENTROPY_PLATFORM`, and potentially `MBEDTLS_FS_IO`, `MBEDTLS_HAVE_TIME_DATE` and `MBEDTLS_HAVE_TIME`.
 
 This is more thoroughly documented in [`mbedtls_config.h`](/api/config_8h.html).
 
@@ -49,7 +49,7 @@ Please note that, for security reasons, the entropy module will refuse to output
 
 ## Hardware Acceleration
 
-You can substitute alternative implementations of cryptographic primitives in most modules that implement them to take advantage of the hardware acceleration that may be present. This can be achieved by defining the appropriate `MBEDTLS_*_ALT` preprocessor symbol for each module that needs to be replaced. For example `MBEDTLS_AES_ALT` may be defined to replace the whole AES API with a hardware accelerated AES driver, and `MBEDTLS_AES_ENCRYPT_ALT` may be defined for replacing only the AES block encrypt functionality. For more information, see the [hardware accelerator guidelines](/kb/development/hw_acc_guidelines.md).
+You can substitute alternative implementations of cryptographic primitives in most modules that implement them to take advantage of the hardware acceleration that may be present. This can be achieved by defining the appropriate `MBEDTLS_*_ALT` preprocessor symbol for each module that needs to be replaced. For example `MBEDTLS_AES_ALT` may be defined to replace the whole AES API with a hardware accelerated AES driver, and `MBEDTLS_AES_ENCRYPT_ALT` may be defined for replacing only the AES block encrypt functionality. For more information, see the [hardware accelerator guidelines](../development/hw_acc_guidelines.md).
 
 ## File system access
 

--- a/kb/how-to/how-do-i-tune-elliptic-curves-resource-usage.md
+++ b/kb/how-to/how-do-i-tune-elliptic-curves-resource-usage.md
@@ -1,6 +1,6 @@
 # How to tune Elliptic Curves resource usage
 
-Like most parts of Mbed TLS, the implementation of elliptic curve operations can be tuned using various [compilation flags](/kb/compiling-and-building/how-do-i-configure-mbedtls.md). This page explains the two parameters that control trade-offs between performance and footprint in more detail than our general documentation on [reducing footprint](reduce-polarssl-memory-and-storage-footprint.md).
+Like most parts of Mbed TLS, the implementation of elliptic curve operations can be tuned using various [compilation flags](../compiling-and-building/how-do-i-configure-mbedtls.md). This page explains the two parameters that control trade-offs between performance and footprint in more detail than our general documentation on [reducing footprint](reduce-polarssl-memory-and-storage-footprint.md).
 
 ## Performance and RAM figures
 

--- a/kb/how-to/how-do-i-tune-elliptic-curves-resource-usage.md
+++ b/kb/how-to/how-do-i-tune-elliptic-curves-resource-usage.md
@@ -4,7 +4,7 @@ Like most parts of Mbed TLS, the implementation of elliptic curve operations can
 
 ## Performance and RAM figures
 
-Since this page discusses performance-footprint trade-offs, it's useful to have some performance figures. For convenience, the figures quoted in this article were collected with Mbed TLS 2.2 on a machine with a 64-bit CPU. You can reproduce those results on your machine using [scripts/ecc-heap.sh](https://github.com/ARMmbed/mbedtls/blob/development/scripts/ecc-heap.sh) from the Mbed TLS sources.
+Since this page discusses performance-footprint trade-offs, it's useful to have some performance figures. For convenience, the figures quoted in this article were collected with Mbed TLS 2.2 on a machine with a 64-bit CPU. You can reproduce those results on your machine using [scripts/ecc-heap.sh](https://github.com/Mbed-TLS/mbedtls/blob/development/scripts/ecc-heap.sh) from the Mbed TLS sources.
 
 The RAM figures only include heap usage, not the stack. This is a limitation of the measurement script. However, these should still be useful, as most memory used by elliptic curve operations will be on the heap. Remember, however, that RAM figures may be slightly lower on a 32-bit machine.
 

--- a/kb/how-to/how_to_integrate_nv_seed.md
+++ b/kb/how-to/how_to_integrate_nv_seed.md
@@ -8,7 +8,7 @@ This makes Mbed TLS use a fixed amount of entropy as a seed and update this seed
 
 # Enabling NV seed entropy source support
 
-You should define `MBEDTLS_ENTROPY_NV_SEED` in your configuration, as described in [this article](/kb/compiling-and-building/how-do-i-configure-mbedtls.md). This ensures the entropy pool knows it can use the NV seed entropy source. You should set the following functions to make the entropy collector call them:
+You should define `MBEDTLS_ENTROPY_NV_SEED` in your configuration, as described in [this article](../compiling-and-building/how-do-i-configure-mbedtls.md). This ensures the entropy pool knows it can use the NV seed entropy source. You should set the following functions to make the entropy collector call them:
 
     int (*mbedtls_nv_seed_write)( unsigned char *buf, size_t buf_len );
     int (*mbedtls_nv_seed_read)( unsigned char *buf, size_t buf_len );

--- a/kb/how-to/increasing_ssl_performance_and_tls_performance.md
+++ b/kb/how-to/increasing_ssl_performance_and_tls_performance.md
@@ -11,7 +11,7 @@ You expect a reasonable performance speed for your SSL connection as well. Howev
 
 ## Explanation
 
-The overhead of the SSL debug module should be negligible when `mbedtls_debug_set_threshold( 0 );` is called. You may still want to [disable **MBEDTLS_DEBUG_C** in `config.h`](/kb/compiling-and-building/how-do-i-configure-mbedtls.md) in order to reduce the footprint and get the last few percent of performance improvement.
+The overhead of the SSL debug module should be negligible when `mbedtls_debug_set_threshold( 0 );` is called. You may still want to [disable **MBEDTLS_DEBUG_C** in `mbedtls_config.h`](/kb/compiling-and-building/how-do-i-configure-mbedtls.md) in order to reduce the footprint and get the last few percent of performance improvement.
 
 <!---increasing_ssl_performance_and_tls_performance
 ,"Small article on increasing the performance of your SSL connection or TLS connection with Mbed TLS",,"performance, debug, speed, optimizations",published,"2014-01-23 15:21:00",2,4163,"2015-07-24 11:52:00","Paul Bakker"--->

--- a/kb/how-to/increasing_ssl_performance_and_tls_performance.md
+++ b/kb/how-to/increasing_ssl_performance_and_tls_performance.md
@@ -11,7 +11,7 @@ You expect a reasonable performance speed for your SSL connection as well. Howev
 
 ## Explanation
 
-The overhead of the SSL debug module should be negligible when `mbedtls_debug_set_threshold( 0 );` is called. You may still want to [disable **MBEDTLS_DEBUG_C** in `mbedtls_config.h`](/kb/compiling-and-building/how-do-i-configure-mbedtls.md) in order to reduce the footprint and get the last few percent of performance improvement.
+The overhead of the SSL debug module should be negligible when `mbedtls_debug_set_threshold( 0 );` is called. You may still want to [disable **MBEDTLS_DEBUG_C** in `mbedtls_config.h`](../compiling-and-building/how-do-i-configure-mbedtls.md) in order to reduce the footprint and get the last few percent of performance improvement.
 
 <!---increasing_ssl_performance_and_tls_performance
 ,"Small article on increasing the performance of your SSL connection or TLS connection with Mbed TLS",,"performance, debug, speed, optimizations",published,"2014-01-23 15:21:00",2,4163,"2015-07-24 11:52:00","Paul Bakker"--->

--- a/kb/how-to/reduce-polarssl-memory-and-storage-footprint.md
+++ b/kb/how-to/reduce-polarssl-memory-and-storage-footprint.md
@@ -4,7 +4,7 @@ This page includes some of the optimizations that can help you reduce the RAM an
 
 All of the settings described on this page are available in `mbedtls_config.h`, see [How do I configure Mbed TLS](../compiling-and-building/how-do-i-configure-mbedtls.md).
 
-If you need to reduce your memory footprint even more or have related questions, please submit a query in our [support forum](https://forums.mbed.com/c/mbed-tls.html) or open an issue in our [GitHub repository](https://github.com/ARMmbed/mbedtls/issues.html). We welcome ideas you may have to further reduce the size in RAM or ROM storage. Please, let us know if you have suggestions for improvements.
+If you need to reduce your memory footprint even more or have related questions, please submit a query in our [support forum](https://forums.mbed.com/c/mbed-tls.html) or open an issue in our [GitHub repository](https://github.com/Mbed-TLS/mbedtls/issues.html). We welcome ideas you may have to further reduce the size in RAM or ROM storage. Please, let us know if you have suggestions for improvements.
 
 # Binary footprint
 
@@ -76,7 +76,7 @@ int mbedtls_x509_crt_parse_der_nocopy( mbedtls_x509_crt *chain,
 ```
 
 The only difference between `mbedtls_x509_crt_parse_der_nocopy()` and `mbedtls_x509_crt_parse_der()` is that the buffer passed to `mbedtls_x509_crt_parse_der_nocopy()` holding the raw DER-encoded certificate must stay unmodified for the lifetime of the established
-X.509 certificate context. See the [documentation](https://github.com/ARMmbed/mbedtls/blob/development/include/mbedtls/x509_crt.h) for more information.
+X.509 certificate context. See the [documentation](https://github.com/Mbed-TLS/mbedtls/blob/development/include/mbedtls/x509_crt.h) for more information.
 
 _Example:_ If your own certificate and/or the trusted CA certificates are hardcoded in ROM, you may use `mbedtls_x509_parse_der_nocopy()` to create X.509 certificate contexts from them without an additional copy in RAM.
 
@@ -91,5 +91,5 @@ If you need to inspect the peer certificate during or immediately after the hand
 
 We provide a few example configurations in the `configs` directory. Two of them feature footprint optimization for a specific usage profile:
 
-* [`config-suite-b.h`](https://github.com/ARMmbed/mbedtls/blob/development/configs/config-suite-b.h) is a minimal configuration supporting NSA Suite B.
-* [`config-ccm-psk-tls1_2.h`](https://github.com/ARMmbed/mbedtls/blob/development/configs/config-ccm-psk-tls1_2.h) is a minimal configuration supporting pre-shared key and with AES-CCM.
+* [`config-suite-b.h`](https://github.com/Mbed-TLS/mbedtls/blob/development/configs/config-suite-b.h) is a minimal configuration supporting NSA Suite B.
+* [`config-ccm-psk-tls1_2.h`](https://github.com/Mbed-TLS/mbedtls/blob/development/configs/config-ccm-psk-tls1_2.h) is a minimal configuration supporting pre-shared key and with AES-CCM.

--- a/kb/how-to/reduce-polarssl-memory-and-storage-footprint.md
+++ b/kb/how-to/reduce-polarssl-memory-and-storage-footprint.md
@@ -2,7 +2,7 @@
 
 This page includes some of the optimizations that can help you reduce the RAM and ROM footprint of the Mbed TLS library. These are generic optimizations that do not require massive modifications to the code. This page discusses reductions of the compiled library (see [Binary footprint](#binary-footprint)) and reductions to the runtime memory (see [Memory footprint](#memory-footprint)).
 
-All of the settings described on this page are available in `config.h`, see [How do I configure Mbed TLS](../compiling-and-building/how-do-i-configure-mbedtls.md).
+All of the settings described on this page are available in `mbedtls_config.h`, see [How do I configure Mbed TLS](../compiling-and-building/how-do-i-configure-mbedtls.md).
 
 If you need to reduce your memory footprint even more or have related questions, please submit a query in our [support forum](https://forums.mbed.com/c/mbed-tls.html) or open an issue in our [GitHub repository](https://github.com/ARMmbed/mbedtls/issues.html). We welcome ideas you may have to further reduce the size in RAM or ROM storage. Please, let us know if you have suggestions for improvements.
 
@@ -12,7 +12,7 @@ The binary footprint is the size of the actual file on disk, in the ROM or the f
 
 ## Minimizing features
 
-By default, Mbed TLS offers several compatibility options and frequently used functionalities. To reduce the footprint, adapt `config.h` to disable the functions that you do not need.
+By default, Mbed TLS offers several compatibility options and frequently used functionalities. To reduce the footprint, adapt `mbedtls_config.h` to disable the functions that you do not need.
 
 # Memory footprint
 

--- a/kb/how-to/ssl_async.md
+++ b/kb/how-to/ssl_async.md
@@ -20,7 +20,7 @@ Support for private key operation callbacks in TLS is turned off by default. To 
 ```
 scripts/config.pl set MBEDTLS_SSL_ASYNC_PRIVATE
 ```
-Alternatively, ensure that the file `include/mbedtls/config.h` contains the following line (a commented-out version of this line is in the default configuration):
+Alternatively, ensure that the [configuration file](../compiling-and-building/how-do-i-configure-mbedtls.md) contains the following line (a commented-out version of this line is in the default configuration):
 ```
 #define MBEDTLS_SSL_ASYNC_PRIVATE
 ```

--- a/kb/how-to/ssl_async.md
+++ b/kb/how-to/ssl_async.md
@@ -18,7 +18,7 @@ This feature is only available for server-side asymmetric cryptography. In Mbed 
 
 Support for private key operation callbacks in TLS is turned off by default. To activate it, build the library with the option `MBEDTLS_SSL_ASYNC_PRIVATE` turned on in the configuration. You can use the following command in the Mbed TLS build tree:
 ```
-scripts/config.pl set MBEDTLS_SSL_ASYNC_PRIVATE
+scripts/config.py set MBEDTLS_SSL_ASYNC_PRIVATE
 ```
 Alternatively, ensure that the [configuration file](../compiling-and-building/how-do-i-configure-mbedtls.md) contains the following line (a commented-out version of this line is in the default configuration):
 ```

--- a/kb/how-to/use-sni.md
+++ b/kb/how-to/use-sni.md
@@ -17,7 +17,7 @@ SNI is enabled in the default configuration.
     ./scripts/config.py set MBEDTLS_X509_CRT_PARSE_C
     ./scripts/config.py set MBEDTLS_SSL_SERVER_NAME_INDICATION
 ```
-These are usual Mbed TLS compile time options, so you need to set them before compiling the library. For more information on configuring Mbed TLS please visit this [knowledge base article](/kb/compiling-and-building/how-do-i-configure-mbedtls.md).
+These are usual Mbed TLS compile time options, so you need to set them before compiling the library. For more information on configuring Mbed TLS please visit this [knowledge base article](../compiling-and-building/how-do-i-configure-mbedtls.md).
 
 ## Configuring the SNI extension
 

--- a/kb/how-to/use-sni.md
+++ b/kb/how-to/use-sni.md
@@ -12,7 +12,7 @@ One possible solution would be to have the virtual servers share a certificate. 
 
 SNI is enabled in the default configuration.
 
-**SNI requires X509 certificates**, so the first step is to enable X509 in your Mbed TLS `config.h` file:
+**SNI requires X509 certificates**, so the first step is to enable X509 in your Mbed TLS [configuration file](../compiling-and-building/how-do-i-configure-mbedtls.md):
 ```
     ./scripts/config.pl set MBEDTLS_X509_CRT_PARSE_C
     ./scripts/config.pl set MBEDTLS_SSL_SERVER_NAME_INDICATION

--- a/kb/how-to/use-sni.md
+++ b/kb/how-to/use-sni.md
@@ -14,8 +14,8 @@ SNI is enabled in the default configuration.
 
 **SNI requires X509 certificates**, so the first step is to enable X509 in your Mbed TLS [configuration file](../compiling-and-building/how-do-i-configure-mbedtls.md):
 ```
-    ./scripts/config.pl set MBEDTLS_X509_CRT_PARSE_C
-    ./scripts/config.pl set MBEDTLS_SSL_SERVER_NAME_INDICATION
+    ./scripts/config.py set MBEDTLS_X509_CRT_PARSE_C
+    ./scripts/config.py set MBEDTLS_SSL_SERVER_NAME_INDICATION
 ```
 These are usual Mbed TLS compile time options, so you need to set them before compiling the library. For more information on configuring Mbed TLS please visit this [knowledge base article](/kb/compiling-and-building/how-do-i-configure-mbedtls.md).
 

--- a/kb/how-to/using-static-memory-instead-of-the-heap.md
+++ b/kb/how-to/using-static-memory-instead-of-the-heap.md
@@ -7,7 +7,7 @@ This currently gives you two options:
 1. Provide your own allocation and freeing functions.
 2. Use the buffer allocator feature in Mbed TLS.
 
-To enable the memory allocation layer, define `MBEDTLS_PLATFORM_C` and `MBEDTLS_PLATFORM_MEMORY` in the `mbedtls_config.h` file. See [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md).
+To enable the memory allocation layer, define `MBEDTLS_PLATFORM_C` and `MBEDTLS_PLATFORM_MEMORY` in the `mbedtls_config.h` file. See [How do I configure Mbed TLS](../compiling-and-building/how-do-i-configure-mbedtls.md).
 
 If you do not enable the layer, the libc standard `calloc()` and `free()` are used.
 

--- a/kb/how-to/using-static-memory-instead-of-the-heap.md
+++ b/kb/how-to/using-static-memory-instead-of-the-heap.md
@@ -7,7 +7,7 @@ This currently gives you two options:
 1. Provide your own allocation and freeing functions.
 2. Use the buffer allocator feature in Mbed TLS.
 
-To enable the memory allocation layer, define `MBEDTLS_PLATFORM_C` and `MBEDTLS_PLATFORM_MEMORY` in the `config.h` file. See [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md).
+To enable the memory allocation layer, define `MBEDTLS_PLATFORM_C` and `MBEDTLS_PLATFORM_MEMORY` in the `mbedtls_config.h` file. See [How do I configure Mbed TLS](/kb/compiling-and-building/how-do-i-configure-mbedtls.md).
 
 If you do not enable the layer, the libc standard `calloc()` and `free()` are used.
 
@@ -24,7 +24,7 @@ The prototypes for these functions are identical to the `libc` standard `calloc(
 
 If your system does not have a `libc` equivalent, you will get compile errors as `calloc()` or `free()` cannot be found.
 
-Defining `MBEDTLS_PLATFORM_NO_STD_FUNCTIONS` in the `config.h` file prevents Mbed TLS from ever knowing about those functions.
+Defining `MBEDTLS_PLATFORM_NO_STD_FUNCTIONS` in the `mbedtls_config.h` file prevents Mbed TLS from ever knowing about those functions.
 
 ### Providing your own hooks
 
@@ -35,7 +35,7 @@ If your operating system already provides an alternative to the `libc` allocator
 
 ## Using the Mbed TLS buffer allocator
 
-If you want Mbed TLS to allocate everything inside a static buffer, you can enable the buffer allocator by defining `MBEDTLS_MEMORY_BUFFER_ALLOC_C` in the `config.h` file.
+If you want Mbed TLS to allocate everything inside a static buffer, you can enable the buffer allocator by defining `MBEDTLS_MEMORY_BUFFER_ALLOC_C` in the `mbedtls_config.h` file.
 
 Before calling any other Mbed TLS functions, enable the buffer allocator as follows:
 


### PR DESCRIPTION
Several minor updates to the knowledge base, mostly for things that were true when written but stopped applying in some 2.x version or in 3.0.

* `config.pl` is now `config.py` (long overdue!)
* `config.h` is now `mbedtls_config.h` (but still acknowledge `config.h`: it's still there in 2.28 LTS)
* Update GitHub `ARMmbed` links to `Mbed-TLS`
* Acknowledge PSA crypto in a few places

I do not have completeness goals here. If I missed a `config.pl` somewhere, this pull request is incomplete. If something completely different needs updating, or if an article needs to have major updates, it's out of scope, and please request or make a follow-up. In particular:

* I didn't add a mention of `MBEDTLS_PSA_CRYPTO_CONFIG`, both because it's a bit too big for this update and because it's still officially an experimental feature.
* `/api` links are broken. We can't fix this until we have somewhere to point them to.
* 