### PR TITLE
Coding standards: loosen naming rules for static functions

### DIFF
--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -120,7 +120,7 @@ Note that all externally linked functions must have a name starting with `mbedtl
 
 Exception: code implementing the PSA crypto API uses the `PSA_` and `psa_` prefixes. This includes official APIs as well as draft APIs that are on the PSA standards track. API extensions which are meant to remain specific to Mbed TLS, and internal functions, should use the `MBEDTLS_/mbedtls_` prefix, however there are many existing cases of using the `PSA_/psa_` prefix.
 
-Exception: macros may have lowercase names if they behave exactly like normal variables and functions. In particular, function-like macros may have lowercase names only if they expand to an expression that evaluates each argument exactly once.
+Exception: macros may have lowercase names if they behave exactly like normal variables and functions. In particular, function-like macros may have lowercase names only if they expand to an expression that evaluates each argument exactly once. Even in those cases, uppercase names are strongly preferred and new code should not use lowercase macro names for anything other than function replacement (like `#define mbedtls_printf printf`).
 
 ### Local names
 

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -122,9 +122,9 @@ Exception: code implementing the PSA crypto API uses the `PSA_` and `psa_` prefi
 
 ### Local names
 
-Static functions can use the same naming scheme as non-static functions (`mbedtls_MODULE_frobnicate()` or `psa_frobnicate()`). This is convenient if they are made non-static later, for example for testing. They can also have shorter names if it's convenient. Keeping the module name (`MODULE_frobnicate()`) as a prefix makes it makes it slightly easier to follow call stacks across modules, but it is not compulsory.
+Static functions can use the same naming scheme as non-static functions (`mbedtls_MODULE_frobnicate()` or `psa_frobnicate()`). This is convenient if they are made non-static later, for example for testing. They can also have shorter names if it's convenient. Keeping the module name (`MODULE_frobnicate()`) as a prefix makes it slightly easier to follow call stacks across modules, but it is not compulsory.
 
-Macros defined only in the `library` directory should follow the same naming scheme as non-static functions (`MBEDTLS_MODULE_FOO` or `PSA_FOO`).The can use shorter names (omitting `MBEDTLS_`, the module name, or both) if it's convenient. However, avoid names without underscores as some embedded platforms define short macro names in their system headers. Exception: macros defined in headers used by alternative implementations or PSA drivers (including headers that they include) must start with with `MBEDTLS_` or `PSA_`.
+Macros defined only in the `library` directory should follow the same naming scheme as non-static functions (`MBEDTLS_MODULE_FOO` or `PSA_FOO`). They can use shorter names (omitting `MBEDTLS_`, the module name, or both) if it's convenient. However, avoid names without underscores as some embedded platforms define short macro names in their system headers. Exception: macros defined in headers used by alternative implementations or PSA drivers (including headers that they include) must start with `MBEDTLS_` or `PSA_`.
 
 All macros must have uppercase names unless they are function-like (expanding to an expression that evaluates each argument exactly once). Using all-uppercase names for preprocessor constants is recommended. Function-like macros, and macros without arguments that expand to function name, usually follow the lowercase naming convention for functions.
 

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -120,13 +120,13 @@ Note that all externally linked functions must have a name starting with `mbedtl
 
 Exception: code implementing the PSA crypto API uses the `PSA_` and `psa_` prefixes. This includes official APIs as well as draft APIs that are on the PSA standards track. API extensions which are meant to remain specific to Mbed TLS, and internal functions, should use the `MBEDTLS_/mbedtls_` prefix, however there are many existing cases of using the `PSA_/psa_` prefix.
 
+Exception: macros may have lowercase names if they behave exactly like normal variables and functions. In particular, function-like macros may have lowercase names only if they expand to an expression that evaluates each argument exactly once.
+
 ### Local names
 
 Static functions can use the same naming scheme as non-static functions (`mbedtls_MODULE_frobnicate()` or `psa_frobnicate()`). This is convenient if they are made non-static later, for example for testing. They can also have shorter names if it's convenient. Keeping the module name (`MODULE_frobnicate()`) as a prefix makes it slightly easier to follow call stacks across modules, but it is not compulsory.
 
 Macros defined only in the `library` directory should follow the same naming scheme as non-static functions (`MBEDTLS_MODULE_FOO` or `PSA_FOO`). They can use shorter names (omitting `MBEDTLS_`, the module name, or both) if it's convenient. However, avoid names without underscores as some embedded platforms define short macro names in their system headers. Exception: macros defined in headers used by alternative implementations or PSA drivers (including headers that they include) must start with `MBEDTLS_` or `PSA_`.
-
-All macros must have uppercase names unless they are function-like (expanding to an expression that evaluates each argument exactly once). Using all-uppercase names for preprocessor constants is recommended. Function-like macros, and macros without arguments that expand to function name, usually follow the lowercase naming convention for functions.
 
 Function parameters and local variables need no name spacing. They should use descriptive names unless they're very short-lived or are used for simple looping or are "standard" names (such as `p` for a pointer to the current position in a buffer).
 

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -116,6 +116,8 @@ All public names (functions, variables, types, `enum` constants, macros) must st
     mbedtls_aes_setkey_decrypt()
 ```
 
+Note that all externally linked functions must have a name starting with `mbedtls_` to avoid link-time conflicts, even if they are not declared in a public header. This also applies to global variables (which should be used very sparingly).
+
 Exception: code implementing the PSA crypto API uses the `PSA_` and `psa_` prefixes. This includes official APIs as well as draft APIs that are on the PSA standards track. API extensions which are meant to remain specific to Mbed TLS, and internal functions, should use the `MBEDTLS_/mbedtls_` prefix, however there are many existing cases of using the `PSA_/psa_` prefix.
 
 ### Local names

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -122,9 +122,9 @@ Exception: code implementing the PSA crypto API uses the `PSA_` and `psa_` prefi
 
 ### Local names
 
-Static functions do not need to have the `mbedtls_` prefix. They usually start with the module name (which makes it slightly easier to follow call stacks across modules), but this is not compulsory.
+Static functions can use the same naming scheme as non-static functions (`mbedtls_MODULE_frobnicate()` or `psa_frobnicate()`). This is convenient if they are made non-static later, for example for testing. They can also have shorter names if it's convenient. Keeping the module name (`MODULE_frobnicate()`) as a prefix makes it makes it slightly easier to follow call stacks across modules, but it is not compulsory.
 
-Macros defined only in the `library` directory should have the `MBEDTLS_` prefix. It's ok to use shorter names if it's convenient, but avoid names without underscores as some embedded platforms define short macro names in their system headers. Exception: macros defined in headers used by alternative implementations or PSA drivers (including headers that they include) must start with with `MBEDTLS_` or `PSA_`.
+Macros defined only in the `library` directory should follow the same naming scheme as non-static functions (`MBEDTLS_MODULE_FOO` or `PSA_FOO`).The can use shorter names (omitting `MBEDTLS_`, the module name, or both) if it's convenient. However, avoid names without underscores as some embedded platforms define short macro names in their system headers. Exception: macros defined in headers used by alternative implementations or PSA drivers (including headers that they include) must start with with `MBEDTLS_` or `PSA_`.
 
 Function parameters and local variables need no name spacing. They should use descriptive names unless they're very short-lived or are used for simple looping or are "standard" names (such as `p` for a pointer to the current position in a buffer).
 

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -122,9 +122,9 @@ Exception: code implementing the PSA crypto API uses the `PSA_` and `psa_` prefi
 
 ### Local names
 
-Static functions and macros that are not in public headers follow the same convention except the initial `MBEDTLS_` or `mbedtls_` prefix: they start directly with the function name.
+Static functions do not need to have the `mbedtls_` prefix. They usually start with the module name (which makes it slightly easier to follow call stacks across modules), but this is not compulsary.
 
-Exception: macros defined in headers used by alternative implementations or PSA drivers (including headers that they include) must start with with `MBEDTLS_` or `PSA_`.
+Macros defined only in the `library` directory should have the `MBEDTLS_` prefix. It's ok to use shorter names if it's convenient, but avoid names without underscores as some embedded platforms define short macro names in their system headers. Exception: macros defined in headers used by alternative implementations or PSA drivers (including headers that they include) must start with with `MBEDTLS_` or `PSA_`.
 
 Function parameters and local variables need no name spacing. They should use descriptive names unless they're very short-lived or are used for simple looping or are "standard" names (such as `p` for a pointer to the current position in a buffer).
 

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -124,6 +124,8 @@ Exception: code implementing the PSA crypto API uses the `PSA_` and `psa_` prefi
 
 Static functions and macros that are not in public headers follow the same convention except the initial `MBEDTLS_` or `mbedtls_` prefix: they start directly with the function name.
 
+Exception: macros defined in headers used by alternative implementations or PSA drivers (including headers that they include) must start with with `MBEDTLS_` or `PSA_`.
+
 Function parameters and local variables need no name spacing. They should use descriptive names unless they're very short-lived or are used for simple looping or are "standard" names (such as `p` for a pointer to the current position in a buffer).
 
 ### Lengths and sizes

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -126,6 +126,8 @@ Static functions can use the same naming scheme as non-static functions (`mbedtl
 
 Macros defined only in the `library` directory should follow the same naming scheme as non-static functions (`MBEDTLS_MODULE_FOO` or `PSA_FOO`).The can use shorter names (omitting `MBEDTLS_`, the module name, or both) if it's convenient. However, avoid names without underscores as some embedded platforms define short macro names in their system headers. Exception: macros defined in headers used by alternative implementations or PSA drivers (including headers that they include) must start with with `MBEDTLS_` or `PSA_`.
 
+All macros must have uppercase names unless they are function-like (expanding to an expression that evaluates each argument exactly once). Using all-uppercase names for preprocessor constants is recommended. Function-like macros, and macros without arguments that expand to function name, usually follow the lowercase naming convention for functions.
+
 Function parameters and local variables need no name spacing. They should use descriptive names unless they're very short-lived or are used for simple looping or are "standard" names (such as `p` for a pointer to the current position in a buffer).
 
 ### Lengths and sizes

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -122,7 +122,7 @@ Exception: code implementing the PSA crypto API uses the `PSA_` and `psa_` prefi
 
 ### Local names
 
-Static functions do not need to have the `mbedtls_` prefix. They usually start with the module name (which makes it slightly easier to follow call stacks across modules), but this is not compulsary.
+Static functions do not need to have the `mbedtls_` prefix. They usually start with the module name (which makes it slightly easier to follow call stacks across modules), but this is not compulsory.
 
 Macros defined only in the `library` directory should have the `MBEDTLS_` prefix. It's ok to use shorter names if it's convenient, but avoid names without underscores as some embedded platforms define short macro names in their system headers. Exception: macros defined in headers used by alternative implementations or PSA drivers (including headers that they include) must start with with `MBEDTLS_` or `PSA_`.
 


### PR DESCRIPTION
Proposal to change coding standards: do not forbid the `mbedtls_` prefix for static functions, and do not require a module name prefix either. Team: please opine :+1: or :-1: emoji on the PR description. 

Rationale: Using the `mbedtls_` prefix on static functions makes it easier to export the function later, which is necessary to write unit tests. Not using a prefix is convenient for small auxiliary functions that are very specific to one module.

Current enforcement: low. As of `mbedtls-3.2.1`, 6% of static function names start with `mbedtls_` and 22% aren't prefix with the module name or something close (many of those in `*_wrap.c` prefixed with the algorithm name). Methodology:
```
perl -l -ne '$f = $ARGV; $f =~ s!.*/!!; $f =~ s!\.c$!!; $b = $f; $b =~ s/_.*|parse$|write$//; $b =~ s/^bignum$/mpi/; if (/^static .*\b([A-Za-z0-9]+)\w+\(/) { if ($1 eq "mbedtls") {++$q} elsif ($1 eq $f || $1 eq $b) {++$m} else {++$o} } END { $t = 1. * ($q + $m + $o); $q/=$t; $m/=$t; $o/=$t; printf "Fully qualified: %.02f\nModule prefix: %.02f\nOther: %.02f\n", $q, $m, $o; }' library/*.c
perl -l -ne '$f = $ARGV; $f =~ s!.*/!!; $f =~ s!\.c$!!; $b = $f; $b =~ s/_.*|parse$|write$//; if (/^static .*\b([A-Za-z0-9]+)\w+\(/) { if ($1 ne "mbedtls" && $1 ne $f && $1 ne $b) { print "$f $1" } }' library/*.c
```

Also in this pull request, closely related and non-controversial:

* Clarify that any exported function counts as public. No rule change, just clarification.
* Note that headers in `library/` used by alternative implementations must not define non-namespaced macro names. Change overdue since Mbed TLS 3.0: before that, alternative implementations did not use headers in `library/`.
