### PR TITLE
Add new Bignum naming conventions

### DIFF
--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -130,8 +130,6 @@ By default all lengths and sizes are in bytes (or in number of elements, for arr
 
 `size` should refer to the capacity of a buffer, and `length` to the length of the contents. Most of the time these are interchangeable. A typical exception is when the output is written in a buffer, but the exact length is not known by the caller.
 
-In PSA code `length` and `size` in the name always implies bytes, when referring to number of elements, `count` is used.
-
 ### Modules: `bignum_core`, `bignum_mod` and `bignum_mod_raw`
 
 Generic conventions:
@@ -143,7 +141,7 @@ Generic conventions:
 
 Length parameters:
 
-- For length of `mbedtls_mpi_uint *` buffers we use `limbs` instead of `count`.
+- For length of `mbedtls_mpi_uint *` buffers we use `limbs`.
 - Length parameters are qualified if possible (e.g. `input_length` or `A_limbs`)
 
 ## API conventions

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -128,6 +128,10 @@ Function parameters and local variables need no name spacing. They should use de
 
 By default all lengths and sizes are in bytes (or in number of elements, for arrays). If a name refers to a length or size in bits (as is often the case for key sizes) then the name must explicitly include `bit`, for example `mbedtls_pk_get_bitlen()` returns the size of the key in bits, while `mbedtls_pk_get_len()` returns the size in bytes. In addition, the documentation should always mention explicitly if key sizes are in bits or in bytes.
 
+Size refers to the capacity of the buffer, while length to the length of the contents. Most of the time these are interchangeable. A typical exception is when the output is written in a buffer, but the exact length is not known by the caller.
+
+In PSA code `length` and `size` in the name always implies bytes, when referring to number of elements, `count` is used.
+
 ## API conventions
 
 This section applies fully to classic `mbedtls_xxx()` APIs and mostly to the newer `psa_xxx()` APIs. PSA have their own [conventions described in the PSA Crypto API specification](https://armmbed.github.io/mbed-crypto/html/overview/conventions.html) which take precedence in case of conflicts.

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -132,6 +132,20 @@ Size refers to the capacity of the buffer, while length to the length of the con
 
 In PSA code `length` and `size` in the name always implies bytes, when referring to number of elements, `count` is used.
 
+### Modules: `bignum_core`, `bignum_mod` and `bignum_mod_raw`
+
+Generic conventions:
+
+- `mbedtls_mpi_uint*` operands should be named by capital letters starting at the beginning of the alphabet (`A`, `B`, `C`, ...).
+- `mbedtls_mpi_uint` operands in turn should be named by lower case letters starting at the beginning of the alphabet (`a`, `b`, `c`)
+- For the result `X` or `x` should be used depending on the type.
+- One of the exceptions from this convention is where the naming of function parameters and local variables follows the literature (eg. Handbook of Applied Cryptography)
+
+Length parameters:
+
+- For length of `mbedtls_mpi_uint*` buffers we use `limbs` instead of `count`.
+- Length parameters are qualified if possible (eg. `input_length` or `A_limbs`)
+
 ## API conventions
 
 This section applies fully to classic `mbedtls_xxx()` APIs and mostly to the newer `psa_xxx()` APIs. PSA have their own [conventions described in the PSA Crypto API specification](https://armmbed.github.io/mbed-crypto/html/overview/conventions.html) which take precedence in case of conflicts.

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -137,7 +137,9 @@ Generic conventions:
 - `mbedtls_mpi_uint *` input operands should be named by capital letters starting at the beginning of the alphabet (`A`, `B`, `C`, ...).
 - `mbedtls_mpi_uint` operands in turn should be named by lower case letters starting at the beginning of the alphabet (`a`, `b`, `c`)
 - For the result `X` or `x` should be used depending on the type.
-- One of the exceptions from this convention is where the naming of function parameters and local variables follows the literature (e.g. Handbook of Applied Cryptography)
+- `N` is generally used for the modulus.
+- `T` is generally used for a temporary work area given to a function.
+- An exception from this convention is where the naming of function parameters and local variables follows the literature (e.g. Handbook of Applied Cryptography)
 
 Length parameters:
 

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -128,7 +128,7 @@ Function parameters and local variables need no name spacing. They should use de
 
 By default all lengths and sizes are in bytes (or in number of elements, for arrays). If a name refers to a length or size in bits (as is often the case for key sizes) then the name must explicitly include `bit`, for example `mbedtls_pk_get_bitlen()` returns the size of the key in bits, while `mbedtls_pk_get_len()` returns the size in bytes. In addition, the documentation should always mention explicitly if key sizes are in bits or in bytes.
 
-Size refers to the capacity of the buffer, while length to the length of the contents. Most of the time these are interchangeable. A typical exception is when the output is written in a buffer, but the exact length is not known by the caller.
+`size` should refer to the capacity of a buffer, and `length` to the length of the contents. Most of the time these are interchangeable. A typical exception is when the output is written in a buffer, but the exact length is not known by the caller.
 
 In PSA code `length` and `size` in the name always implies bytes, when referring to number of elements, `count` is used.
 
@@ -136,15 +136,15 @@ In PSA code `length` and `size` in the name always implies bytes, when referring
 
 Generic conventions:
 
-- `mbedtls_mpi_uint*` operands should be named by capital letters starting at the beginning of the alphabet (`A`, `B`, `C`, ...).
+- `mbedtls_mpi_uint *` input operands should be named by capital letters starting at the beginning of the alphabet (`A`, `B`, `C`, ...).
 - `mbedtls_mpi_uint` operands in turn should be named by lower case letters starting at the beginning of the alphabet (`a`, `b`, `c`)
 - For the result `X` or `x` should be used depending on the type.
-- One of the exceptions from this convention is where the naming of function parameters and local variables follows the literature (eg. Handbook of Applied Cryptography)
+- One of the exceptions from this convention is where the naming of function parameters and local variables follows the literature (e.g. Handbook of Applied Cryptography)
 
 Length parameters:
 
-- For length of `mbedtls_mpi_uint*` buffers we use `limbs` instead of `count`.
-- Length parameters are qualified if possible (eg. `input_length` or `A_limbs`)
+- For length of `mbedtls_mpi_uint *` buffers we use `limbs` instead of `count`.
+- Length parameters are qualified if possible (e.g. `input_length` or `A_limbs`)
 
 ## API conventions
 


### PR DESCRIPTION
We agreed on a couple of naming conventions regarding the new Bignum work. This PR is for recording it in the coding standard.

Also added some clarifications to the naming conventions regarding length.