### PR TITLE
Coding style: preprocessor hygiene

### DIFF
--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -244,20 +244,9 @@ Since often systems that use Mbed TLS do not have a file system, functions speci
 
 ### Minimize use of macros
 
-Avoid using macros unless:
-* Readability actually improves with use of the macro.
-* Code size is drastically impacted.
+Only use macros if they improve readability or maintainability, preferably both. If macros seem necessary for maintainability but hinder readability, consider generating code from a Python script instead.
 
-The following define actually makes the code using it easier to read.
-```c
-#define GET_UINT32_LE( n, b, i )                        \
-{                                                       \
-    (n) = ( (uint32_t) (b)[(i)    ]       )             \
-        | ( (uint32_t) (b)[(i) + 1] <<  8 )             \
-        | ( (uint32_t) (b)[(i) + 2] << 16 )             \
-        | ( (uint32_t) (b)[(i) + 3] << 24 );            \
-}
-```
+If possible, use the C core language rather than macros. For example, if an expression is used often, a `static inline` function is better because it provides type checks, allows the compiler to keep the function call when optimizing for size, and avoids problems with arguments evaluated more than once. However, if the expression needs to be a compile-time constant when its parameters are, this is a good reason to use a macro.
 
 ## Clear security-relevant memory after use
 

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -324,7 +324,7 @@ When the code contains a macro call `MBEDTLS_FOO( x, y )`, it should behave as m
 
 If the arguments of a macro are C expressions (they usually are), put parentheses around the argument in the expansion. For example:
 ```c
-#define FOO_SIZE( bits ) ( ( (bits) + 7 ) / 8 + 4)
+#define FOO_SIZE( bits ) ( ( (bits) + 7 ) / 8 + 4 )
 ```
 The expansion contains `( (bits) + 7 )`, not `bits + 7`, so that a call like `FOO_SIZE( x << 3 )` is parsed correctly. As an exception, it's ok to omit parentheses if the argument is directly passed to a function argument (or comma operator): `#define A( x ) f( x, 0 )` is acceptable.
 

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -328,7 +328,7 @@ If the arguments of a macro are C expressions (they usually are), put parenthese
 ```
 The expansion contains `( (bits) + 7 )`, not `bits + 7`, so that a call like `FOO_SIZE( x << 3 )` is parsed correctly. As an exception, it's ok to omit parentheses if the argument is directly passed to a function argument (or comma operator): `#define A( x ) f( x, 0 )` is acceptable.
 
-If the expansion of a macro is a C expression, put parentheses around the expansion. Continuing the example above, this is so that a call like `FOO_SIZE( x ) * 2` is parsed correctly. As an exception, it's ok to omit parentheses if the expansion is a function call or other lowest-precedence operator: `#define A( x ) f( x, 0 )` is acceptable.
+If the expansion of a macro is a C expression, put parentheses around the expansion. Continuing the example above, this is so that a call like `FOO_SIZE( x ) * 2` is parsed correctly. As an exception, it's ok to omit parentheses if the expansion is a function call or other highest-precedence operator: `#define A( x ) f( x, 0 )` is acceptable.
 
 If a macro expands to a statement, wrap it in `do { ... } while( 0 )` so that it can be used in contexts that expect a single statement. For example:
 ```c

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -347,7 +347,7 @@ Follow the expression paradigm or the statement paradigm if possible. Other para
 ```
 The expansion of a macro must not contain unbalanced parentheses, brackets or braces.
 
-In macro expansions, do make assumptions about the calling context, for example do not assume that a particular variable is defined. Exception: variable names with a very strong convention in the code base, like the `ret` example above which is systematically used for status codes in the classic mbedtls API. If the macro needs an intermediate variable, give it a long name that won't clash with anything else, but strongly consider using a function instead.
+In macro expansions, do not make assumptions about the calling context, for example do not assume that a particular variable is defined. Exception: variable names with a very strong convention in the code base, like the `ret` example above which is systematically used for status codes in the classic mbedtls API. If the macro needs an intermediate variable, give it a long name that won't clash with anything else, but strongly consider using a function instead.
 
 ## Clear security-relevant memory after use
 

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -347,6 +347,8 @@ Follow the expression paradigm or the statement paradigm if possible. Other para
 ```
 The expansion of a macro must not contain unbalanced parentheses, brackets or braces.
 
+In macro expansions, do make assumptions about the calling context, for example do not assume that a particular variable is defined. Exception: variable names with a very strong convention in the code base, like the `ret` example above which is systematically used for status codes in the classic mbedtls API. If the macro needs an intermediate variable, give it a long name that won't clash with anything else, but strongly consider using a function instead.
+
 ## Clear security-relevant memory after use
 
 Memory that contains security-relevant information should be set to zero after use, and before being released to be reused. Use the function `mbedtls_platform_zeroize()` to prevent unwanted compiler optimization.

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -330,7 +330,7 @@ The expansion contains `( (bits) + 7 )`, not `bits + 7`, so that a call like `FO
 
 If the expansion of a macro is a C expression, put parentheses around the expansion. Continuing the example above, this is so that a call like `FOO_SIZE( x ) * 2` is parsed correctly. As an exception, it's ok to omit parentheses if the expansion is a function call or other lowest-precedence operator: `#define A( x ) f( x, 0 )` is acceptable.
 
-If a macro expands to an instruction, wrap it in `do { ... } while( 0 )` so that it can be used in contexts that expect a single instruction. For example:
+If a macro expands to a statement, wrap it in `do { ... } while( 0 )` so that it can be used in contexts that expect a single statement. For example:
 ```c
 #define MBEDTLS_MPI_CHK(f)       \
     do                           \
@@ -341,7 +341,7 @@ If a macro expands to an instruction, wrap it in `do { ... } while( 0 )` so that
 ```
 The expansion is not just `if( ( ret = (f) ) != 0 ) goto cleanup` because that would not work in a context like `if( condition ) MBEDTLS_MPI_CHK( f( ) ); else ++x;` (the `else` would get attached to the wrong `if`).
 
-Follow the expression paradigm or the instruction paradigm if possible. Other paradigms are permitted if necessary, for example a macro that expands to an initializer such as
+Follow the expression paradigm or the statement paradigm if possible. Other paradigms are permitted if necessary, for example a macro that expands to an initializer such as
 ```c
 #define MBEDTLS_FOO_INIT {0, {0, 0}}
 ```


### PR DESCRIPTION
Add sections on preprocessor macro hygiene to the coding style:

* Hygiene of macro expansions: parentheses around arguments, parentheses or `do {…} while (0)` around expansions.
* Hygiene of conditional compilation: preferably around whole instructions, never around unbalanced code.

This is a little more strict than what we have now. What we have now is sometimes confusing, for example neither uncrustify nor clang-tidy+clang-format can cope with some of the unbalanced code we have now (see “Refactor macro-spanning ifs” commits in https://github.com/Mbed-TLS/mbedtls/pull/6397 — pull requests with just those fixes coming soon).
