### PR TITLE
Coding style: formatting of lists

### DIFF
--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -99,6 +99,13 @@ Similarly, sizeof expressions always use parentheses even when it is not necessa
 
 ### Formatting of lists
 
+When a function or macro call doesn't fit on a single line, put one argument per line or a sensible grouping per line. For example, in the snippet below, `input_buffer` and `input_size` are on a line of their own even though the call could fit on two lines instead of three if they were separated:
+```c
+    function_with_a_very_long_name( parameter1, parameter2,
+                                    input_buffer, input_size,
+                                    output_buffer, output_size );
+```
+
 Lists of items other than function arguments should generally have one item per line. Exceptions:
 
 * It's ok to write simple structure initializers on a single line.

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -119,7 +119,7 @@ typedef enum foo
     FOO_2,      // <- do put a comma here
 }
 ```
-This doesn't apply to structure initializers that fit on one line.
+Exceptions: you can and omit the trailing comma in structure initializers that fit on one line, or if the last element must always remain last (e.g. a null terminator).
 
 ### Preprocessor directives
 

--- a/kb/development/mbedtls-coding-standards.md
+++ b/kb/development/mbedtls-coding-standards.md
@@ -97,6 +97,23 @@ Similarly, sizeof expressions always use parentheses even when it is not necessa
     memset( buf, 0, sizeof( buf ) );
 ```
 
+### Formatting of lists
+
+Lists of items other than function arguments should generally have one item per line. Exceptions:
+
+* It's ok to write simple structure initializers on a single line.
+* In an array initialized with numerical data, pack a sensible and consistent number of items per line. The number of items per line should be a power of 2 to faciliate counting.
+
+In lists of items such array initializers and enum definitions, do include the optional comma after the last element. This simplifies merging, reordering, etc.
+```c
+typedef enum foo
+{
+    FOO_1,
+    FOO_2,      // <- do put a comma here
+}
+```
+This doesn't apply to structure initializers that fit on one line.
+
 ### Preprocessor directives
 
 When using preprocessor directives to enable or disable parts of the code, use `#if defined` instead of `#ifdef`. Add a comment to the `#endif` directive if the distance to the opening directive is bigger than a few lines or contains other directives:


### PR DESCRIPTION
* Function calls: group arguments sensibly
* Initializers and enum: one item per line, or sensible groups of numerical values
* Include trailing commas

This would also apply to scripts, but [PEP8](https://peps.python.org/pep-0008/#when-to-use-trailing-commas) covers trailing commas, so I don't think we need anything explicit in the script coding style.