### PR TITLE
Rewrite a branch with the new coding style

### DIFF
--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -188,6 +188,12 @@ class BranchRewriter:
         This function only constructs a path, it does not create the worktree.
         """
         assert self.original_worktree_path is not None
+        # If arg is a branch name, it can contain a slash. This is fine for git,
+        # but it causes the worktree's directory path to be weird, which is
+        # potentially when cleaning up, both in this script and for the user.
+        # So use a different character that is valid in directory names
+        # but not in git branch names.
+        arg = arg.replace('/', '%')
         worktree_dir = 'tmp-{arg}-{pid}'.format(arg=arg, pid=os.getpid())
         return os.path.join(os.path.dirname(self.original_worktree_path),
                             worktree_dir)

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -190,9 +190,9 @@ class BranchRewriter:
         assert self.original_worktree_path is not None
         # If arg is a branch name, it can contain a slash. This is fine for git,
         # but it causes the worktree's directory path to be weird, which is
-        # potentially when cleaning up, both in this script and for the user.
-        # So use a different character that is valid in directory names
-        # but not in git branch names.
+        # potentially annoying when cleaning up, both in this script and for
+        # the user. So use a different character that is valid in directory
+        # names but not in git branch names.
         arg = arg.replace('/', '%')
         worktree_dir = 'tmp-{arg}-{pid}'.format(arg=arg, pid=os.getpid())
         return os.path.join(os.path.dirname(self.original_worktree_path),

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -226,7 +226,7 @@ class BranchRewriter:
         assert self.worktree_path is None
         self.worktree_path = self.generate_worktree_path(branch)
         self.info('Creating worktree: {}', self.worktree_path)
-        self.run_git(['worktree', 'add', self.worktree_path])
+        self.run_git(['worktree', 'add', '--detach', self.worktree_path])
         os.chdir(self.worktree_path)
         self.run_git_checkout(branch)
         self.do_rewrite(branch)

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -107,6 +107,7 @@ class BranchRewriter:
         Categories:
         * 'heads' = local branch
         * 'remotes' = remote name slash remote branch
+        * 'sha' = sha of a commit
         * 'tags' = tag
         """
         if category == 'sha':
@@ -202,9 +203,12 @@ class BranchRewriter:
         self.run_git(['worktree', 'remove', worktree_path])
 
     def create_backup_branch(self, template: str, ref: str) -> None:
-        """Create a branch new_name pointing to ref.
+        """Create a branch pointing to ref.
 
-        Do nothing if new_name already points to ref.
+        The name of the new branch is template with `{}` replaced by ref.
+
+        Do nothing if there is already a branch with that name that points to
+        ref. If a branch exists with a different head, raise an error.
         """
         new_name = self.fill_branch_name_template(template, ref, 'backup')
         try:

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -26,7 +26,7 @@ from typing import List, Optional
 
 
 class BranchRewriter:
-    """Rebase and rewrite a branch of Mbed TLS."""
+    """Tools to rebase and rewrite a Git branch."""
 
     GIT_EXE = 'git'
 
@@ -148,7 +148,38 @@ class BranchRewriter:
             self.cleanup_worktree()
 
 
-class CodeStyleBranchRewriter(BranchRewriter):
+class MbedTLSBranchRewriter(BranchRewriter):
+    #pylint: disable=abstract-method # This class is still abstract
+    """Tools to rebase and rewrite a branch of Mbed TLS."""
+
+    UPSTREAM_URLS = frozenset(map(lambda s: s.lower(), [
+        'git@github.com:ARMmbed/mbedtls.git',
+        'git@github.com:Mbed-TLS/mbedtls.git',
+        'https://github.com/ARMmbed/mbedtls.git',
+        'https://github.com/Mbed-TLS/mbedtls.git',
+    ]))
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.upstream_remote = None #type: Optional[str]
+
+    def guess_upstream_remote(self) -> None:
+        """Find a Git remote for the upstream repository."""
+        if self.upstream_remote is not None:
+            return
+        self.info('Enumerating Git remotes...')
+        remotes = self.get_git_lines(['remote', '-v', 'show'])
+        for remote in remotes:
+            (name, rest) = remote.split('\t', 2)
+            (url, rest) = rest.split(' ', 1)
+            if url.lower() in self.UPSTREAM_URLS:
+                self.info('Found upstream remote: {}', name)
+                self.upstream_remote = name
+                return
+        raise ValueError('No Git remote found for upstream')
+
+
+class CodeStyleBranchRewriter(MbedTLSBranchRewriter):
     """Rebase and rewrite a branch of Mbed TLS to the new coding style."""
 
     UNCRUSTIFY_SUPPORTED_VERSION = "0.75.1"

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -84,6 +84,61 @@ class BranchRewriter:
         """The sha of the git HEAD."""
         return self.run_git(['rev-parse', 'HEAD']).strip()
 
+    def is_git_ref(self, category: str, ref: str) -> bool:
+        """Whether ref is a Git ref of the given category.
+
+        Categories:
+        * 'heads' = local branch
+        * 'remotes' = remote name slash remote branch
+        * 'tags' = tag
+        """
+        if category == 'sha':
+            try:
+                # Don't accidentally pass an option to 'git rev-parse'
+                # (it doesn't support --).
+                if not ref.startswith('-'):
+                    if self.run_git(['rev-parse', ref]).strip() == ref:
+                        return True
+                return False
+            except subprocess.CalledProcessError:
+                # Not a valid ref. It's not our job to raise an exception.
+                return False
+        path = 'refs/{}/{}'.format(category, ref)
+        return self.check_git(['show-ref', '--quiet', '--verify', path])
+
+    def ref_looks_ok_for_template(self, ref: str) -> bool:
+        """Whether ref looks ok to build another branch name on.
+
+        It must be a branch, tag or sha.
+        In particular, reject HEAD.
+        """
+        if self.is_git_ref('heads', ref):
+            return True
+        if self.is_git_ref('remotes', ref):
+            return True
+        if self.is_git_ref('tags', ref):
+            return True
+        if self.is_git_ref('sha', ref):
+            return True
+        return False
+
+    def fill_branch_name_template(self, template: str, ref: str,
+                                  kind: str) -> str:
+        """Build a branch name based on a template.
+
+        Replace '{}' by ref if present (otherwise return template unchanged).
+        ref must be a branch, tag or sha.
+        kind is a short, human-readable description of the template's purpose.
+        """
+        if '{}' not in template:
+            return template
+        if not self.ref_looks_ok_for_template(ref):
+            self.log_error('Cannot create branch name for {} from {}',
+                           kind, ref)
+            raise ValueError('Bad ref {} for {} branch name template {}'
+                             .format(ref, kind, template))
+        return template.replace('{}', ref)
+
     def list_commit_range(self, start: str, last: str) -> List[str]:
         """List the commits from start to last, excluding last."""
         commits = self.get_git_lines(['rev-list', start + '..' + last])
@@ -128,6 +183,27 @@ class BranchRewriter:
             return
         self.info('Removing worktree: {}', worktree_path)
         self.run_git(['worktree', 'remove', worktree_path])
+
+    def create_backup_branch(self, template: str, ref: str) -> None:
+        """Create a branch new_name pointing to ref.
+
+        Do nothing if new_name already points to ref.
+        """
+        new_name = self.fill_branch_name_template(template, ref, 'backup')
+        try:
+            old_name_target = self.run_git(['rev-parse', ref],
+                                           stderr=subprocess.DEVNULL)
+            new_name_target = self.run_git(['rev-parse', new_name],
+                                           stderr=subprocess.DEVNULL)
+            if old_name_target == new_name_target:
+                self.info('Backup branch {} already points to {}', new_name, ref)
+                return
+        except subprocess.CalledProcessError:
+            # Commonly, new_name does not exist, and that's a good case for us.
+            # If some other error occurred (e.g. ref is invalid), ignore it:
+            # let 'git branch' fail with a more informative error.
+            self.info('Creating backup branch {} for {}', new_name, ref)
+            self.run_git(['branch', '--no-track', new_name, ref])
 
     def do_rewrite(self, branch: str) -> None:
         """Rewrite the given branch.
@@ -374,6 +450,11 @@ class CodeStyleBranchRewriter(MbedTLSBranchRewriter):
 def main() -> int:
     """Command line entry point."""
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--backup-branch', metavar='BRANCH_NAME',
+                        default='old-code-style/{}',
+                        help='Back up the current history'
+                             ' (default: old-code-style/OLD_NAME)'
+                             ' (empty: do not back up)')
     parser.add_argument('--onto', '-t', metavar='BRANCH',
                         help='Branch to rewrite onto'
                              ' (default/empty: guess development or mbedtls-2.28)')
@@ -388,6 +469,8 @@ def main() -> int:
         branch_rewriter.set_target_branch(args.onto)
     if not branch_rewriter.system_is_ok():
         return 2
+    if args.backup_branch:
+        branch_rewriter.create_backup_branch(args.backup_branch, args.branch)
     branch_rewriter.rewrite(args.branch)
     branch_rewriter.cleanup()
     return 0 if branch_rewriter.ok else 1

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -471,20 +471,34 @@ class CodeStyleBranchRewriter(MbedTLSBranchRewriter):
     def restyle_commit_onto_current(self, new_commit: str) -> None:
         """Apply a restyled content of new_commit onto HEAD."""
         self.info('Applying {} onto {}', new_commit, self.head_sha())
-        # Cherry-pick the commit to apply. Resolve all conflicts in
-        # favor of the new commit: we want the new commit's content,
-        # with the current commit's history.
+        # We want the new commit's metadata (author, commit message),
+        # the new commit's content (but restyled), and the old commit's
+        # history. This is a cherry-pick operation, with some custom
+        # way to merge the contents. We could perhaps define a custom merge
+        # strategy, but that seems hard (especially since we do want to
+        # tweak the content even if there are no merge conflicts). So we
+        # pick some method of resolving the conflict automatically
+        # that ensures that added and removed files are according to the
+        # cherry-picked commit, but might mess up modified files. Then
+        # we override the content of modified files, and finally we restyle
+        # files that need restyling.
         self.run_git(['cherry-pick', '-Xtheirs', '--allow-empty', new_commit])
+        self.info('{} has been cherry-picked as {}', new_commit, self.head_sha())
         # Restyle the code to the new style. Only restyle changed files.
         changed_files = self.changed_files_in_commit('HEAD')
-        files_to_restyle = self.filter_styled_files(changed_files)
-        if files_to_restyle:
-            self.restyle_files(files_to_restyle)
-            # Amend the commit to contain the result of restyling.
-            self.run_git(['commit', '--amend', '--no-edit',
-                          '--allow-empty', '--'] +
-                         files_to_restyle)
-        self.info('{} has been applied as {}', new_commit, self.head_sha())
+        if changed_files:
+            self.run_git(['reset', '--quiet', new_commit, '--'] + changed_files)
+            self.run_git(['commit', '--amend', '--no-edit', '--allow-empty'])
+            self.run_git(['reset', '--quiet', '--hard'])
+            self.info('{} has been amended to {}', new_commit, self.head_sha())
+            files_to_restyle = self.filter_styled_files(changed_files)
+            if files_to_restyle:
+                self.restyle_files(files_to_restyle)
+                # Amend the commit to contain the result of restyling.
+                self.run_git(['commit', '--amend', '--no-edit',
+                              '--allow-empty', '--'] +
+                             files_to_restyle)
+        self.info('{} has been restyled as {}', new_commit, self.head_sha())
 
     def do_rewrite(self, branch: str) -> None:
         """Rewrite branch on top of the code style switch commit.

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -30,10 +30,14 @@ class BranchRewriter:
 
     GIT_EXE = 'git'
 
-    def __init__(self, verbose=False) -> None:
+    def __init__(self,
+                 working_branch_name: Optional[str] = None,
+                 verbose=False) -> None:
         self.verbose = verbose
         self.original_worktree_path = None # type: Optional[str]
         self.worktree_path = None # type: Optional[str]
+        self.working_branch_name = \
+            working_branch_name if working_branch_name else None
         self.ok = True
 
     def info(self, fmt, *args, **kwargs) -> None:
@@ -229,6 +233,9 @@ class BranchRewriter:
         self.run_git(['worktree', 'add', '--detach', self.worktree_path])
         os.chdir(self.worktree_path)
         self.run_git_checkout(branch)
+        if self.working_branch_name:
+            self.info('Working on new branch {}', self.working_branch_name)
+            self.run_git(['checkout', '--quiet', '-b', self.working_branch_name])
         self.do_rewrite(branch)
         os.chdir(self.original_worktree_path)
         self.cleanup_worktree()
@@ -444,6 +451,9 @@ class CodeStyleBranchRewriter(MbedTLSBranchRewriter):
                   len(new_commits), ' '.join(new_commits))
         self.info('Starting from code style switch commit {}', switch_commit)
         self.run_git_checkout(switch_commit)
+        if self.working_branch_name:
+            self.run_git(['branch', '--force', self.working_branch_name, 'HEAD'])
+            self.run_git(['checkout', '--quiet', self.working_branch_name])
         for new_commit in new_commits:
             self.restyle_commit_onto_current(new_commit)
 
@@ -458,13 +468,19 @@ def main() -> int:
     parser.add_argument('--onto', '-t', metavar='BRANCH',
                         help='Branch to rewrite onto'
                              ' (default/empty: guess development or mbedtls-2.28)')
+    parser.add_argument('--new-branch-name', '-c', metavar='BRANCH_NAME',
+                        default='',
+                        help='Use this branch for the new work (retained on failure),'
+                             ' do not change the original branch')
     parser.add_argument('--verbose', '-v',
                         action='store_true',
                         help='be more verbose')
     parser.add_argument('branch',
                         help='Branch to rewrite with code style changes')
     args = parser.parse_args()
-    branch_rewriter = CodeStyleBranchRewriter(verbose=args.verbose)
+    branch_rewriter = CodeStyleBranchRewriter(
+        working_branch_name=args.new_branch_name,
+        verbose=args.verbose)
     if args.onto:
         branch_rewriter.set_target_branch(args.onto)
     if not branch_rewriter.system_is_ok():

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -255,7 +255,7 @@ class CodeStyleBranchRewriter(BranchRewriter):
         # Cherry-pick the commit to apply. Resolve all conflicts in
         # favor of the new commit: we want the new commit's content,
         # with the current commit's history.
-        self.run_git(['cherry-pick', '-Xtheirs', new_commit])
+        self.run_git(['cherry-pick', '-Xtheirs', '--allow-empty', new_commit])
         # Restyle the code to the new style. Only restyle changed files.
         changed_files = self.changed_files_in_commit('HEAD')
         files_to_restyle = self.filter_styled_files(changed_files)

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -279,21 +279,16 @@ class BranchRewriter:
             self.run_git(['checkout', '--quiet', '-b', self.working_branch_name])
         self.do_rewrite(branch)
         self.rewritten_sha = self.head_sha()
-        if update_branch:
-            self.info('Moving branch {} from {} to {}',
-                      branch, original_branch_sha, self.rewritten_sha)
-            self.run_git(['branch', '--force', branch, self.rewritten_sha])
+
         os.chdir(self.original_worktree_path)
         if update_original_worktree:
-#            # Always be verbose about updating the original working directory
-#            self.run_git(['checkout', branch])
-            # We've renamed the branch, so `git checkout $branch` wouldn't
-            # update the working directory content. We only update the worktree
-            # if it had the branch checked out (assumption on our caller!), so
-            # we don't actually need a checkout here, just a reset.
+            # Always be verbose about updating the original working directory
+            self.run_git(['checkout', branch])
             # A hard reset is safe because we stopped earlier if the working
             # directory was dirty.
-            self.run_git(['reset', '--hard', branch])
+            self.info('Moving branch {} from {} to {}',
+                      branch, original_branch_sha, self.rewritten_sha)
+            self.run_git(['reset', '--hard', self.rewritten_sha])
         self.cleanup_worktree()
 
     def cleanup(self) -> None:

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -69,6 +69,11 @@ class BranchRewriter:
         """The sha of the git HEAD."""
         return self.run_git(['rev-parse', 'HEAD']).strip()
 
+    def list_commit_range(self, start: str, last: str) -> List[str]:
+        """List the commits from start to last, excluding last."""
+        commits = self.get_git_lines(['rev-list', start + '..' + last])
+        return list(reversed(commits))
+
     def system_is_ok(self) -> bool:
         """Check that the required tools are present and the working directory is suitable."""
         ok = True
@@ -175,11 +180,6 @@ class CodeStyleBranchRewriter(BranchRewriter):
                            self.UNCRUSTIFY_SUPPORTED_VERSION)
             ok = False
         return ok
-
-    def list_commit_range(self, start: str, last: str) -> List[str]:
-        """List the commits from start to last, excluding last."""
-        commits = self.get_git_lines(['rev-list', start + '..' + last])
-        return list(reversed(commits))
 
     def find_switch_commit(self) -> str:
         """Return the sha of the commit with the code style switch."""

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Rewrite an Mbed TLS branch on top of the new coding style.
+"""
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import os
+import pathlib
+import subprocess
+import sys
+from typing import List, Optional
+
+
+class BranchRewriter:
+    """Rebase and rewrite a branch of Mbed TLS."""
+
+    GIT_EXE = 'git'
+
+    def __init__(self, verbose=False) -> None:
+        self.verbose = verbose
+        self.original_worktree_path = None # type: Optional[str]
+        self.worktree_path = None # type: Optional[str]
+        self.ok = True
+
+    def info(self, fmt, *args, **kwargs) -> None:
+        """In verbose mode, print a formatted message."""
+        if self.verbose:
+            sys.stderr.write(fmt.format(*args, **kwargs) + '\n')
+
+    def log_error(self, fmt, *args, **kwargs) -> None:
+        """Print a formatted message and remember that an error occurred."""
+        self.ok = False
+        sys.stderr.write(fmt.format(*args, **kwargs) + '\n')
+
+    def run_git(self, git_cmd: List[str], **kwargs) -> str:
+        """Run a git command and return its output."""
+        if 'universal_newlines' not in kwargs:
+            kwargs['universal_newlines'] = True
+        cmd = [self.GIT_EXE] + git_cmd
+        return subprocess.check_output(cmd, **kwargs)
+
+    def run_git_checkout(self, revision: str) -> None:
+        """Check out the given revision in detached mode."""
+        self.run_git(['checkout', '--detach', '--quiet', revision])
+
+    def head_sha(self) -> str:
+        """The sha of the git HEAD."""
+        return self.run_git(['rev-parse', 'HEAD']).strip()
+
+    def system_is_ok(self) -> bool:
+        """Check that the required tools are present and the working directory is suitable."""
+        ok = True
+        # 'git worktree remove' was added in Git 2.17.0. It's the most
+        # recent Git feature that we need.
+        output = self.run_git(['worktree', '--help'])
+        if 'git worktree remove' not in output:
+            self.log_error('Your version of Git is too old. This script needs Git >=2.17.0.')
+            ok = False
+        # Check that we're in a Git working directory. Remember its path.
+        output = self.run_git(['rev-parse', '--show-toplevel'])
+        self.original_worktree_path = output.rstrip('\n')
+        self.info('Git root: {}', self.original_worktree_path)
+        return ok
+
+    def generate_worktree_path(self, arg: str) -> str:
+        """Generate the path to a temporary worktree.
+
+        This function only constructs a path, it does not create the worktree.
+        """
+        assert self.original_worktree_path is not None
+        worktree_dir = 'tmp-{arg}-{pid}'.format(arg=arg, pid=os.getpid())
+        return os.path.join(os.path.dirname(self.original_worktree_path),
+                            worktree_dir)
+
+    def cleanup_worktree(self) -> None:
+        """Remove the temporary worktree.
+
+        Do nothing if the temporary worktree does not exist.
+        """
+        worktree_path = self.worktree_path
+        self.worktree_path = None
+        if worktree_path is None: # not named yet
+            return
+        if not os.path.exists(worktree_path): # not created yet
+            self.info('No worktree to clean up: {}', worktree_path)
+            return
+        self.info('Removing worktree: {}', worktree_path)
+        self.run_git(['worktree', 'remove', worktree_path])
+
+    def do_rewrite(self, branch: str) -> None:
+        """Rewrite the given branch.
+
+        Do not call this method directly: call rewrite().
+
+        Override this method in child classes to do the desired rewriting.
+
+        This method is called with the current directory in a temporary
+        Git worktree with branch checked out in detached mode.
+        """
+        raise NotImplementedError
+
+    def rewrite(self, branch: str) -> None:
+        """Rewrite the given branch.
+
+        This method creates a temporary Git worktree and changes to it.
+        """
+        assert self.original_worktree_path is not None
+        assert self.worktree_path is None
+        self.worktree_path = self.generate_worktree_path(branch)
+        self.info('Creating worktree: {}', self.worktree_path)
+        self.run_git(['worktree', 'add', self.worktree_path])
+        os.chdir(self.worktree_path)
+        self.run_git_checkout(branch)
+        self.do_rewrite(branch)
+        os.chdir(self.original_worktree_path)
+        self.cleanup_worktree()
+
+    def cleanup(self) -> None:
+        """Clean up after a successful run."""
+        if self.ok:
+            self.cleanup_worktree()
+
+
+class CodeStyleBranchRewriter(BranchRewriter):
+    """Rebase and rewrite a branch of Mbed TLS to the new coding style."""
+
+    UNCRUSTIFY_SUPPORTED_VERSION = "0.75.1"
+    CONFIG_FILE = ".uncrustify.cfg"
+    UNCRUSTIFY_EXE = "uncrustify"
+
+    GENERATED_FILES_2_28 = frozenset([
+        pathlib.PurePath('library/error.c'),
+        pathlib.PurePath('library/version_features.c'),
+        pathlib.PurePath('programs/psa/psa_constant_names_generated.c'),
+        pathlib.PurePath('programs/test/query_config.c'),
+    ])
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.target_branch = None #type: Optional[str]
+
+    def set_target_branch(self, target_branch: str) -> None:
+        """Record the given branch as the branch to rewrite onto."""
+        self.target_branch = target_branch
+
+    def system_is_ok(self) -> bool:
+        ok = super().system_is_ok()
+        output = subprocess.check_output([self.UNCRUSTIFY_EXE, '--version'],
+                                         universal_newlines=True)
+        self.info('Found uncrustify: {}', output.strip())
+        if self.UNCRUSTIFY_SUPPORTED_VERSION not in output:
+            self.log_error('Unsupported version of uncrustify. This script needs {}.',
+                           self.UNCRUSTIFY_SUPPORTED_VERSION)
+            ok = False
+        return ok
+
+    def list_commit_range(self, start: str, last: str) -> List[str]:
+        """List the commits from start to last, excluding last."""
+        output = self.run_git(['rev-list', start + '..' + last])
+        return list(reversed(output.split()))
+
+    def find_switch_commit(self) -> str:
+        """Return the sha of the commit with the code style switch."""
+        assert self.target_branch is not None
+        revision = self.target_branch + '^{/Switch to the new code style}'
+        sha = self.run_git(['rev-parse', revision]).strip()
+        self.info('Switch commit: {}', sha)
+        return sha
+
+    def changed_files_in_commit(self, revision: str) -> List[str]:
+        """The list of files changed or added in the given revision."""
+        # The git command prints a list of the form:
+        #   * 'A\t{filename}' for an added file
+        #   * 'M\t{filename}' for a modified file
+        #   * 'D\t{filename}' for a deleted file
+        #   * 'R{confidence}\t{old_name}\t{new_name}' for a renamed file
+        output = self.run_git(['show', '--format=', '--name-status', revision])
+        filenames = []
+        for line in output.rstrip('\n').split('\n'):
+            if line[0] == 'D': # deleted file
+                continue
+            pos = line.rfind('\t') + 1
+            filenames.append(line[pos:])
+        return filenames
+
+    @staticmethod
+    def is_c_file(path: pathlib.PurePath) -> bool:
+        """Whether path is a C source file, based on its name and location."""
+        dir_chain = path.parts[:-1]
+        if path.suffix in {'.c', '.h'}:
+            return True
+        if dir_chain == ('tests', 'suites') and path.suffix == '.function':
+            return True
+        if dir_chain == ('scripts', 'data_files') and path.suffix == '.fmt':
+            return True
+        return False
+
+    def is_file_exempt(self, path: pathlib.PurePath) -> Optional[str]:
+        """Whether path is exempt from restyling.
+
+        Return the reason why path is exempt (a non-empty string),
+        or None if path is not exempt.
+        """
+        if path.parts[0] == '3rdparty':
+            return '3rdparty'
+        # Hard-coded list of files that are generated in 2.28.
+        # In development, generated files are not checked into Git.
+        if path.parts in self.GENERATED_FILES_2_28:
+            return 'generated'
+        return None
+
+    def filter_styled_files(self, filenames: List[str]) -> List[str]:
+        """Return filenames with non-restylable files removed."""
+        keep = []
+        for filename in filenames:
+            path = pathlib.PurePath(filename)
+            if not self.is_c_file(path):
+                continue
+            why_exempt = self.is_file_exempt(path)
+            if why_exempt:
+                self.info('Exempt from restyling ({}): {}', why_exempt, filename)
+                continue
+            self.info('Will restyle: {}', filename)
+            keep.append(filename)
+        return keep
+
+    def restyle_files(self, filenames: List[str]) -> None:
+        """Restyle the given files in place."""
+        if not filenames:
+            return
+        for num in range(2):
+            self.info('Pass #{} of uncrustify', num)
+            subprocess.check_call([self.UNCRUSTIFY_EXE,
+                                   '-c', self.CONFIG_FILE,
+                                   '--no-backup'] +
+                                  filenames)
+
+    def restyle_commit_onto_current(self, new_commit: str) -> None:
+        """Apply a restyled content of new_commit onto HEAD."""
+        self.info('Applying {} onto {}', new_commit, self.head_sha())
+        # Cherry-pick the commit to apply. Resolve all conflicts in
+        # favor of the new commit: we want the new commit's content,
+        # with the current commit's history.
+        self.run_git(['cherry-pick', '-Xtheirs', new_commit])
+        # Restyle the code to the new style. Only restyle changed files.
+        changed_files = self.changed_files_in_commit('HEAD')
+        files_to_restyle = self.filter_styled_files(changed_files)
+        if files_to_restyle:
+            self.restyle_files(files_to_restyle)
+            # Amend the commit to contain the result of restyling.
+            self.run_git(['commit', '--amend', '--no-edit',
+                          '--allow-empty', '--'] +
+                         files_to_restyle)
+        self.info('{} has been applied as {}', new_commit, self.head_sha())
+
+    def do_rewrite(self, branch: str) -> None:
+        """Rewrite branch on top of the code style switch commit.
+
+        1. Rebase the head of branch onto the last commit with the old style.
+        2. Rewrite all new commits on top of the code style switch commit.
+
+        This method assumes it has ownership of the current worktree.
+        It does not create or modify any branch name.
+        """
+        switch_commit = self.find_switch_commit()
+        last_old_commit = switch_commit + '~1'
+        # Phase 1: rebase onto last_old_commit
+        self.info('Rebasing {} onto {}', self.head_sha(), last_old_commit)
+        self.run_git(['rebase', last_old_commit])
+        self.info('Head after rebase: {}', self.head_sha())
+        # Phase 2: Iterate over the new commits
+        new_commits = self.list_commit_range(last_old_commit, 'HEAD')
+        self.info('Will restyle {} new commits ({})',
+                  len(new_commits), ' '.join(new_commits))
+        self.info('Starting from code style switch commit {}', switch_commit)
+        self.run_git_checkout(switch_commit)
+        for new_commit in new_commits:
+            self.restyle_commit_onto_current(new_commit)
+
+def main() -> int:
+    """Command line entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--verbose', '-v',
+                        action='store_true',
+                        help='be more verbose')
+    parser.add_argument('existing_branch',
+                        help='Branch to rewrite with code style changes')
+    parser.add_argument('target_branch',
+                        help='Branch to rewrite onto')
+    args = parser.parse_args()
+    branch_rewriter = CodeStyleBranchRewriter(verbose=args.verbose)
+    if not branch_rewriter.system_is_ok():
+        return 2
+    branch_rewriter.set_target_branch(args.target_branch)
+    branch_rewriter.rewrite(args.existing_branch)
+    branch_rewriter.cleanup()
+    return 0 if branch_rewriter.ok else 1
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -287,8 +287,8 @@ class MbedTLSBranchRewriter(BranchRewriter):
     UPSTREAM_URLS = frozenset(map(lambda s: s.lower(), [
         'git@github.com:ARMmbed/mbedtls.git',
         'git@github.com:Mbed-TLS/mbedtls.git',
-        'https://github.com/ARMmbed/mbedtls.git',
-        'https://github.com/Mbed-TLS/mbedtls.git',
+        'https://github.com/ARMmbed/mbedtls',
+        'https://github.com/Mbed-TLS/mbedtls',
     ]))
 
     def __init__(self, *args, **kwargs) -> None:

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -1,5 +1,7 @@
 #!/usr/bin/env python3
 """Rewrite an Mbed TLS branch on top of the new coding style.
+
+Invoke this script from a Git working directory with a branch of Mbed TLS.
 """
 
 # Copyright The Mbed TLS Contributors
@@ -505,15 +507,25 @@ def main() -> int:
                         action='store_true',
                         help='be more verbose')
     parser.add_argument('branch',
-                        help='Branch to rewrite with code style changes')
+                        nargs='?', default='',
+                        help='Branch to rewrite with code style changes'
+                             ' (default: branch checked out in the current directory)')
     args = parser.parse_args()
     branch_rewriter = CodeStyleBranchRewriter(
         working_branch_name=args.new_branch_name,
         verbose=args.verbose)
-    if args.onto:
-        branch_rewriter.set_target_branch(args.onto)
     if not branch_rewriter.system_is_ok():
         return 2
+    if not args.branch:
+        args.branch = branch_rewriter.checked_out_branch()
+        if not args.branch:
+            if '{}' in args.backup_branch:
+                branch_rewriter.log_error('No branch specified and detached head. Unable to construct backup branch name.')
+                branch_rewriter.log_error('Giving up. Please pass an explicit branch name or --backup-branch.')
+                return 2
+            args.branch = 'HEAD'
+    if args.onto:
+        branch_rewriter.set_target_branch(args.onto)
     if args.backup_branch:
         branch_rewriter.create_backup_branch(args.backup_branch, args.branch)
     update_existing_branch = False

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -57,6 +57,14 @@ class BranchRewriter:
         """Check out the given revision in detached mode."""
         self.run_git(['checkout', '--detach', '--quiet', revision])
 
+    def get_git_lines(self, git_cmd: List[str], **kwargs) -> List[str]:
+        """Run a git command and return its output, split into lines.
+
+        Ignore trailing empty lines, but preserve leading and inner empty lines.
+        """
+        output = self.run_git(git_cmd, **kwargs)
+        return output.rstrip('\n').split('\n')
+
     def head_sha(self) -> str:
         """The sha of the git HEAD."""
         return self.run_git(['rev-parse', 'HEAD']).strip()
@@ -170,8 +178,8 @@ class CodeStyleBranchRewriter(BranchRewriter):
 
     def list_commit_range(self, start: str, last: str) -> List[str]:
         """List the commits from start to last, excluding last."""
-        output = self.run_git(['rev-list', start + '..' + last])
-        return list(reversed(output.split()))
+        commits = self.get_git_lines(['rev-list', start + '..' + last])
+        return list(reversed(commits))
 
     def find_switch_commit(self) -> str:
         """Return the sha of the commit with the code style switch."""
@@ -188,13 +196,11 @@ class CodeStyleBranchRewriter(BranchRewriter):
         #   * 'M\t{filename}' for a modified file
         #   * 'D\t{filename}' for a deleted file
         #   * 'R{confidence}\t{old_name}\t{new_name}' for a renamed file
-        output = self.run_git(['show', '--format=', '--name-status', revision])
-        filenames = []
-        for line in output.rstrip('\n').split('\n'):
-            if line[0] == 'D': # deleted file
-                continue
-            pos = line.rfind('\t') + 1
-            filenames.append(line[pos:])
+        lines = self.get_git_lines(['show', '--format=', '--name-status',
+                                    revision])
+        filenames = [line.rsplit('\t', 1)[-1]
+                     for line in lines
+                     if line[0] != 'D'] # skip deleted files
         return filenames
 
     @staticmethod

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -285,8 +285,15 @@ class BranchRewriter:
             self.run_git(['branch', '--force', branch, self.rewritten_sha])
         os.chdir(self.original_worktree_path)
         if update_original_worktree:
-            # Always be verbose about updating the original working directory
-            self.run_git(['checkout', branch])
+#            # Always be verbose about updating the original working directory
+#            self.run_git(['checkout', branch])
+            # We've renamed the branch, so `git checkout $branch` wouldn't
+            # update the working directory content. We only update the worktree
+            # if it had the branch checked out (assumption on our caller!), so
+            # we don't actually need a checkout here, just a reset.
+            # A hard reset is safe because we stopped earlier if the working
+            # directory was dirty.
+            self.run_git(['reset', '--hard', branch])
         self.cleanup_worktree()
 
     def cleanup(self) -> None:

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -157,6 +157,11 @@ class BranchRewriter:
                              .format(ref, kind, template))
         return template.replace('{}', ref)
 
+    def working_directory_is_clean(self) -> bool:
+        """Check whether the Git working directory is clean (no uncommited changes)."""
+        return (self.check_git(['diff', '--quiet']) and
+                self.check_git(['diff', '--quiet', '--cached']))
+
     def list_commit_range(self, start: str, last: str) -> List[str]:
         """List the commits from start to last, excluding last."""
         commits = self.get_git_lines(['rev-list', start + '..' + last])
@@ -252,6 +257,10 @@ class BranchRewriter:
         update_original_worktree = False
         original_branch_sha = self.run_git(['rev-parse', branch]).strip()
         if update_branch and self.checked_out_branch() == branch:
+            if not self.working_directory_is_clean():
+                self.log_error('Refusing to update branch and working tree because the working tree is dirty.')
+                self.log_error('Hint: commit your changes first.')
+                return
             self.info('Will update original worktree on success')
             update_original_worktree = True
         self.worktree_path = self.generate_worktree_path(branch)

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -53,6 +53,21 @@ class BranchRewriter:
         cmd = [self.GIT_EXE] + git_cmd
         return subprocess.check_output(cmd, **kwargs)
 
+    def check_git(self, git_cmd: List[str], **kwargs) -> bool:
+        """Run a git command for its boolean result.
+
+        Return True if the command returns 0 and False if it returns 1.
+        Raise subprocess.CalledProcessError for any other status.
+        """
+        cmd = [self.GIT_EXE] + git_cmd
+        cp = subprocess.run(cmd, check=False, **kwargs)
+        if cp.returncode == 0:
+            return True
+        elif cp.returncode == 1:
+            return False
+        else:
+            raise subprocess.CalledProcessError(cp.returncode, cmd)
+
     def run_git_checkout(self, revision: str) -> None:
         """Check out the given revision in detached mode."""
         self.run_git(['checkout', '--detach', '--quiet', revision])
@@ -193,6 +208,10 @@ class CodeStyleBranchRewriter(MbedTLSBranchRewriter):
         pathlib.PurePath('programs/test/query_config.c'),
     ])
 
+    # To be updated once the new code style becomes official,
+    # or possibly change to tags instead of branches.
+    TARGET_BRANCH_PREFIX = 'features/new-code-style/'
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.target_branch = None #type: Optional[str]
@@ -212,8 +231,32 @@ class CodeStyleBranchRewriter(MbedTLSBranchRewriter):
             ok = False
         return ok
 
+    def guess_target_branch(self) -> None:
+        """Guess the branch that the current branch is to be merged into.
+
+        This method sets self.target_branch. It does nothing if that is
+        already set.
+
+        This method assumes development unless the branch forked from
+        an LTS branch.
+        """
+        if self.target_branch is not None:
+            return
+        self.guess_upstream_remote()
+        self.info('Guessing target branch...')
+        if self.check_git(['merge-base', '--is-ancestor',
+                           'mbedtls-2.28.0', 'HEAD']):
+            branch = 'mbedtls-2.28'
+        else:
+            branch = 'development'
+        self.target_branch = '{}/{}{}'.format(self.upstream_remote,
+                                              self.TARGET_BRANCH_PREFIX,
+                                              branch)
+        self.info('Guessed target branch: {}', self.target_branch)
+
     def find_switch_commit(self) -> str:
         """Return the sha of the commit with the code style switch."""
+        self.guess_target_branch()
         assert self.target_branch is not None
         revision = self.target_branch + '^{/Switch to the new code style}'
         sha = self.run_git(['rev-parse', revision]).strip()
@@ -331,19 +374,21 @@ class CodeStyleBranchRewriter(MbedTLSBranchRewriter):
 def main() -> int:
     """Command line entry point."""
     parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--onto', '-t', metavar='BRANCH',
+                        help='Branch to rewrite onto'
+                             ' (default/empty: guess development or mbedtls-2.28)')
     parser.add_argument('--verbose', '-v',
                         action='store_true',
                         help='be more verbose')
-    parser.add_argument('existing_branch',
+    parser.add_argument('branch',
                         help='Branch to rewrite with code style changes')
-    parser.add_argument('target_branch',
-                        help='Branch to rewrite onto')
     args = parser.parse_args()
     branch_rewriter = CodeStyleBranchRewriter(verbose=args.verbose)
+    if args.onto:
+        branch_rewriter.set_target_branch(args.onto)
     if not branch_rewriter.system_is_ok():
         return 2
-    branch_rewriter.set_target_branch(args.target_branch)
-    branch_rewriter.rewrite(args.existing_branch)
+    branch_rewriter.rewrite(args.branch)
     branch_rewriter.cleanup()
     return 0 if branch_rewriter.ok else 1
 

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -38,6 +38,7 @@ class BranchRewriter:
         self.worktree_path = None # type: Optional[str]
         self.working_branch_name = \
             working_branch_name if working_branch_name else None
+        self.rewritten_sha = None #type: Optional[str]
         self.ok = True
 
     def info(self, fmt, *args, **kwargs) -> None:
@@ -87,6 +88,16 @@ class BranchRewriter:
     def head_sha(self) -> str:
         """The sha of the git HEAD."""
         return self.run_git(['rev-parse', 'HEAD']).strip()
+
+    def checked_out_branch(self) -> Optional[str]:
+        """The name of the branch checked out in the Git working directory.
+
+        None if no branch is checked out (detached HEAD).
+        """
+        branch_name = self.run_git(['rev-parse', '--abbrev-ref', 'HEAD']).strip()
+        if branch_name == 'HEAD':
+            return None
+        return branch_name
 
     def is_git_ref(self, category: str, ref: str) -> bool:
         """Whether ref is a Git ref of the given category.
@@ -221,13 +232,22 @@ class BranchRewriter:
         """
         raise NotImplementedError
 
-    def rewrite(self, branch: str) -> None:
+    def rewrite(self, branch: str, update_branch: bool = False) -> None:
         """Rewrite the given branch.
 
         This method creates a temporary Git worktree and changes to it.
+
+        If update_branch is true and the rewrite succeeds, update branch
+        to the rewritten commit and check it out in the current directory
+        if it was already checked out before.
         """
         assert self.original_worktree_path is not None
         assert self.worktree_path is None
+        update_original_worktree = False
+        original_branch_sha = self.run_git(['rev-parse', branch]).strip()
+        if update_branch and self.checked_out_branch() == branch:
+            self.info('Will update original worktree on success')
+            update_original_worktree = True
         self.worktree_path = self.generate_worktree_path(branch)
         self.info('Creating worktree: {}', self.worktree_path)
         self.run_git(['worktree', 'add', '--detach', self.worktree_path])
@@ -237,7 +257,15 @@ class BranchRewriter:
             self.info('Working on new branch {}', self.working_branch_name)
             self.run_git(['checkout', '--quiet', '-b', self.working_branch_name])
         self.do_rewrite(branch)
+        self.rewritten_sha = self.head_sha()
+        if update_branch:
+            self.info('Moving branch {} from {} to {}',
+                      branch, original_branch_sha, self.rewritten_sha)
+            self.run_git(['branch', '--force', branch, self.rewritten_sha])
         os.chdir(self.original_worktree_path)
+        if update_original_worktree:
+            # Always be verbose about updating the original working directory
+            self.run_git(['checkout', branch])
         self.cleanup_worktree()
 
     def cleanup(self) -> None:
@@ -471,7 +499,8 @@ def main() -> int:
     parser.add_argument('--new-branch-name', '-c', metavar='BRANCH_NAME',
                         default='',
                         help='Use this branch for the new work (retained on failure),'
-                             ' do not change the original branch')
+                             ' do not change the original branch'
+                             ' (default/empty: update original branch on success)')
     parser.add_argument('--verbose', '-v',
                         action='store_true',
                         help='be more verbose')
@@ -487,8 +516,23 @@ def main() -> int:
         return 2
     if args.backup_branch:
         branch_rewriter.create_backup_branch(args.backup_branch, args.branch)
-    branch_rewriter.rewrite(args.branch)
+    update_existing_branch = False
+    if not args.new_branch_name:
+        if branch_rewriter.is_git_ref('heads', args.branch):
+            update_existing_branch = True
+    branch_rewriter.rewrite(args.branch, update_existing_branch)
     branch_rewriter.cleanup()
+    if branch_rewriter.ok and \
+       not args.new_branch_name and not update_existing_branch:
+        # The new work isn't available except via a sha, so it seems pretty
+        # important to let the user know even in non-verbose mode.
+        # Use wording similar to "leaving N commits behind" from 'git checkout'.
+        sys.stderr.write("""Warning: the rewritten commits are not connected to any branch.
+
+You should give them a name with:
+
+ git branch <new-branch-name> {sha}
+""".format(sha=branch_rewriter.rewritten_sha))
     return 0 if branch_rewriter.ok else 1
 
 if __name__ == '__main__':

--- a/tools/test/.gitignore
+++ b/tools/test/.gitignore
@@ -1,0 +1,3 @@
+/clone-for-test
+/worktree-for-test-*
+/tmp-*-*

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -241,7 +241,7 @@ class Tests(unittest.TestCase):
 
     def delete_temporary_branches(self, case_id: str) -> None:
         branches = self.git_lines(['for-each-ref', '--format=%(refname:short)',
-                                   'tmp/{}/*'.format(case_id)])
+                                   'refs/heads/tmp/{}/**'.format(case_id)])
         if branches:
             self.call_git(['branch', '--quiet', '--delete', '--force'] +
                           branches)

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -210,7 +210,7 @@ class Tests(unittest.TestCase):
         range_diff = self.git_lines(['range-diff', '--no-color',
                                      common_ancestor, branch1, branch2])
         for line in range_diff:
-            self.assertRegex(line, r'\A[0-9]+: *[0-9a-f]+ = ')
+            self.assertRegex(line, r'\A *[0-9]+: *[0-9a-f]+ *= ')
 
     @classmethod
     def setUpClass(cls) -> None:

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -21,7 +21,6 @@ Needs git >=2.19.
 # limitations under the License.
 
 import contextlib
-import enum
 import os
 import subprocess
 from typing import Iterator, List, Optional
@@ -66,27 +65,18 @@ class temp_git_worktree:
                                self.temp_path])
 
 
-class TestCommits(enum.Enum):
-    # Snapshots used by the tests of branches and tags used by the script.
-    development = ('development', 'b4b0bb737d51ac34a91de269aad4432524be5794')
-    mbedtls_2_28 = ('mbedtls-2.28', 'a6ad7f47023b235fc8d02c3f2bbb5d5277c2f20f')
-    mbedtls_2_28_0 = ('mbedtls-2.28.0', '8b3f26a5ac38d4fdccbc5c5366229f3e01dafcc0')
-
-    # Snapshots of branches and pull requests used by the tests.
-    pr_6784 = ('pull/6784', 'ea8c88fcbb85917b7e323c016f9ba47bbd55f930')
-    pr_6863 = ('pull/6863', 'e79fb03b7cd19dcf5a31b4eb478416694e965222')
-
-    def tag(self) -> str:
-        return self.value[0]
-
-    def sha(self) -> str:
-        return self.value[1]
-
-
 class Utilities(unittest.TestCase):
 
     GIT_DIR = 'clone-for-test'
     ORIGIN_URL = 'https://github.com/Mbed-TLS/mbedtls'
+    FETCH_BRANCHES = [
+        'features/new-code-style/development',
+        'features/new-code-style/mbedtls-2.28',
+        'features/new-code-style/test/*',
+    ]
+    FETCH_TAGS = [
+        'mbedtls-2.28.0', # for target branch detection
+    ]
     SCRIPT_NAME = 'mbedtls-rewrite-branch-style'
 
     script = None #type: Optional[str]
@@ -164,17 +154,11 @@ class Utilities(unittest.TestCase):
         This method is destructive. It may create, update or remove branches,
         tags, worktrees, worktree contents, etc.
         """
-        cls.call_git(['fetch', '--quiet', 'origin'] +
-                     [commit.sha() for commit in TestCommits])
-        for commit in TestCommits:
-            cls.call_git(['tag', '--force', commit.tag(), commit.sha()])
-        # TODO: when guessing the target branch, we need the
-        # features/new-code-style/* branches. But they'll get out of synch
-        # of the snapshot commit IDs hard-coded in these tests.
-        cls.call_git(['fetch', '--quiet', '--force', 'origin',
-                      'refs/heads/features/new-code-style/*:refs/remotes/origin/features/new-code-style/*'])
-        cls.call_git(['fetch', '--quiet', '--force', 'origin',
-                      'refs/tags/features/new-code-style/*:refs/remotes/origin/features/new-code-style/*'])
+        cls.call_git(['fetch', '--quiet', '--force', 'origin'] +
+                     ['refs/tags/{name}:refs/tags/{name}'.format(name=name)
+                      for name in cls.FETCH_TAGS] +
+                     ['refs/heads/{name}:refs/remotes/origin/{name}'.format(name=name)
+                      for name in cls.FETCH_BRANCHES])
         # Make sure the main worktree doesn't have a branch checked out that
         # might interfere with some of the tests.
         cls.call_git(['checkout', '--quiet', '--detach'])
@@ -284,28 +268,63 @@ class Smoke(Utilities):
         self.assertNotEqual(cp.stderr, '')
 
 class Result(Utilities):
+    """Test that running the script on a given branch gives the expected result.
 
-    def test_detached_6863(self) -> None:
+    To add a new test case:
+    * Pick a branch to test and a name $foo.
+    * Run the rewrite script and carefully review the output.
+    * Push the original branch, the target branch and the rewritten branch
+      to the main mbedtls repository in the features/new-code-style/test
+      namespace.
+
+    For example:
+    ```
+    mbedtls-rewrite-branch-style --onto=origin/features/new-code-style/development --backup-branch=1234-old --new-branch=1234-new
+    : review the output
+    git push origin 1234-old:refs/heads/features/new-code-style/test/1234/old
+    git push origin origin/features/new-code-style/development:refs/heads/features/new-code-style/test/1234/target
+    git push origin 1234-new:refs/heads/features/new-code-style/test/1234/new
+    ```
+    """
+
+    OLD_BRANCH = 'origin/features/new-code-style/test/{}/old'
+    TARGET_BRANCH = 'origin/features/new-code-style/test/{}/target'
+    GOOD_NEW_BRANCH = 'origin/features/new-code-style/test/{}/new'
+
+    def run_on_branch(self, name) -> None:
+        old_branch = self.OLD_BRANCH.format(name)
+        target_branch = self.TARGET_BRANCH.format(name)
+        target_commit = target_branch + '^{/Switch to the new code style}'
         new_branch = self.temp_branch('new')
-        with self.temp_worktree(head='pull/6863') as worktree:
+        with self.temp_worktree(head=old_branch) as worktree:
             cp = self.run_script(['-v', '--backup-branch=',
+                                  '--onto', target_branch,
                                   '--new-branch', new_branch],
                                  cwd=worktree.path)
             self.assertEqual(cp.returncode, 0)
-            self.assert_same_history('origin/features/new-code-style/development~1',
-                                     'origin/features/new-code-style/test/good/new/6863',
+            self.assert_same_history(target_commit,
+                                     self.GOOD_NEW_BRANCH.format(name),
                                      new_branch)
 
-class Options(Utilities):
+    def test_6863(self) -> None:
+        self.run_on_branch('6863')
 
-    def test_updating_6863(self) -> None:
+class Options(Utilities):
+    old_branch = 'origin/features/new-code-style/test/6863/old'
+    target_branch = 'origin/features/new-code-style/test/6863/target'
+    target_commit = target_branch + '^{/Switch to the new code style}'
+    good_new_branch = 'origin/features/new-code-style/test/6863/new'
+
+    def test_update_in_place(self) -> None:
         temp_branch = self.temp_branch('work')
-        with self.temp_worktree(branch=temp_branch, head='pull/6863') as worktree:
-            cp = self.run_script(['-v', '--backup-branch='],
+        with self.temp_worktree(branch=temp_branch,
+                                head=self.old_branch) as worktree:
+            cp = self.run_script(['-v', '--backup-branch=',
+                                  '--onto', self.target_branch],
                                  cwd=worktree.path)
             self.assertEqual(cp.returncode, 0)
-            self.assert_same_history('origin/features/new-code-style/development~1',
-                                     'origin/features/new-code-style/test/good/new/6863',
+            self.assert_same_history(self.target_commit,
+                                     self.good_new_branch,
                                      temp_branch)
 
 

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -83,7 +83,7 @@ class TestCommits(enum.Enum):
         return self.value[1]
 
 
-class Tests(unittest.TestCase):
+class Utilities(unittest.TestCase):
 
     GIT_DIR = 'clone-for-test'
     ORIGIN_URL = 'https://github.com/Mbed-TLS/mbedtls'
@@ -268,6 +268,8 @@ class Tests(unittest.TestCase):
                               stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                               universal_newlines=True)
 
+class Smoke(Utilities):
+
     def test_help(self) -> None:
         cp = self.run_script(['--help'])
         self.assertEqual(cp.returncode, 0)
@@ -281,6 +283,8 @@ class Tests(unittest.TestCase):
         self.assertEqual(cp.stdout, '')
         self.assertNotEqual(cp.stderr, '')
 
+class Result(Utilities):
+
     def test_detached_6863(self) -> None:
         new_branch = self.temp_branch('new')
         with self.temp_worktree(head='pull/6863') as worktree:
@@ -291,6 +295,8 @@ class Tests(unittest.TestCase):
             self.assert_same_history('origin/features/new-code-style/development~1',
                                      'origin/features/new-code-style/test/good/new/6863',
                                      new_branch)
+
+class Options(Utilities):
 
     def test_updating_6863(self) -> None:
         temp_branch = self.temp_branch('work')

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -289,7 +289,7 @@ class Tests(unittest.TestCase):
                                  cwd=worktree.path)
             self.assertEqual(cp.returncode, 0)
             self.assert_same_history('origin/features/new-code-style/development~1',
-                                     'origin/features/new-code-style/test/new/6863',
+                                     'origin/features/new-code-style/test/good/new/6863',
                                      new_branch)
 
     def test_updating_6863(self) -> None:
@@ -299,7 +299,7 @@ class Tests(unittest.TestCase):
                                  cwd=worktree.path)
             self.assertEqual(cp.returncode, 0)
             self.assert_same_history('origin/features/new-code-style/development~1',
-                                     'origin/features/new-code-style/test/new/6863',
+                                     'origin/features/new-code-style/test/good/new/6863',
                                      temp_branch)
 
 

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -73,7 +73,6 @@ class TestCommits(enum.Enum):
     # Snapshots of branches and pull requests used by the tests.
     pr_6784 = ('pull/6784', 'ea8c88fcbb85917b7e323c016f9ba47bbd55f930')
     pr_6863 = ('pull/6863', 'e79fb03b7cd19dcf5a31b4eb478416694e965222')
-    pr_6866 = ('pull/6866', 'ff7d7c3a9a4c5afa9dda0c3e7a8c0f3211b0a366')
 
     def tag(self) -> str:
         return self.value[0]
@@ -289,17 +288,6 @@ class Tests(unittest.TestCase):
             self.assertEqual(cp.returncode, 0)
             self.assert_same_history('origin/features/new-code-style/development~1',
                                      'origin/features/new-code-style/test/new/6863',
-                                     new_branch)
-
-    def test_detached_6866(self) -> None:
-        new_branch = self.temp_branch('new')
-        with self.temp_worktree(head='pull/6866') as worktree:
-            cp = self.run_script(['-v', '--backup-branch=',
-                                  '--new-branch', new_branch],
-                                 cwd=worktree.path)
-            self.assertEqual(cp.returncode, 0)
-            self.assert_same_history('origin/features/new-code-style/development~1',
-                                     'origin/features/new-code-style/test/new/6866',
                                      new_branch)
 
     def test_updating_6863(self) -> None:

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
 """Tests for mbedtls-rewrite-branch-style.
+
+Needs git >=2.19.
 """
 
 # Copyright The Mbed TLS Contributors

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -309,6 +309,36 @@ class Result(Utilities):
     def test_6863(self) -> None:
         self.run_on_branch('6863')
 
+    def test_6888(self) -> None:
+        self.run_on_branch('6888')
+
+    def test_6889(self) -> None:
+        self.run_on_branch('6889')
+
+
+class Detection(Utilities):
+    """Test target branch detection."""
+
+    OLD_BRANCH = 'origin/features/new-code-style/test/{}/old'
+
+    def run_on_branch(self, name, expected_target) -> None:
+        old_branch = self.OLD_BRANCH.format(name)
+        new_branch = self.temp_branch('new')
+        with self.temp_worktree(head=old_branch) as worktree:
+            cp = self.run_script(['-v', '--backup-branch=',
+                                  '--new-branch', new_branch],
+                                 cwd=worktree.path)
+            self.assertEqual(cp.returncode, 0)
+            self.assertRegex(cp.stderr,
+                             r'Guessed target branch: (\S+/)?' + expected_target)
+
+    def test_6888(self) -> None:
+        self.run_on_branch('6888', 'development')
+
+    def test_6889(self) -> None:
+        self.run_on_branch('6889', 'mbedtls-2.28')
+
+
 class Options(Utilities):
     old_branch = 'origin/features/new-code-style/test/6863/old'
     target_branch = 'origin/features/new-code-style/test/6863/target'

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -1,0 +1,305 @@
+#!/usr/bin/env python3
+
+"""Tests for mbedtls-rewrite-branch-style.
+"""
+
+# Copyright The Mbed TLS Contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import contextlib
+import enum
+import os
+import subprocess
+from typing import Iterator, List, Optional
+import unittest
+
+
+
+class temp_git_worktree:
+    """Run code in a temporary Git worktree."""
+
+    def __init__(
+            self,
+            main_path: str, temp_path: str,
+            branch: Optional[str] = None,
+            head: Optional[str] = None
+    ) -> None:
+        self.main_path = os.path.abspath(main_path)
+        self.temp_path = os.path.abspath(temp_path)
+        self.branch = branch
+        self.head = head
+
+    @property
+    def path(self):
+        """The absolute path to the worktree."""
+        return self.temp_path
+
+    def __enter__(self) -> 'temp_git_worktree':
+        cmd = ['git', '-C', self.main_path, 'worktree', 'add', '--quiet']
+        if self.branch is None:
+            cmd += ['--detach']
+        else:
+            cmd += ['-b', self.branch]
+        cmd += [self.temp_path]
+        if self.head is not None:
+            cmd += [self.head]
+        subprocess.check_call(cmd)
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        subprocess.check_call(['git', '-C', self.main_path,
+                               'worktree', 'remove', '--force',
+                               self.temp_path])
+
+
+class TestCommits(enum.Enum):
+    # Snapshots used by the tests of branches and tags used by the script.
+    development = ('development', 'b4b0bb737d51ac34a91de269aad4432524be5794')
+    mbedtls_2_28 = ('mbedtls-2.28', 'a6ad7f47023b235fc8d02c3f2bbb5d5277c2f20f')
+    mbedtls_2_28_0 = ('mbedtls-2.28.0', '8b3f26a5ac38d4fdccbc5c5366229f3e01dafcc0')
+
+    # Snapshots of branches and pull requests used by the tests.
+    pr_6784 = ('pull/6784', 'ea8c88fcbb85917b7e323c016f9ba47bbd55f930')
+    pr_6863 = ('pull/6863', 'e79fb03b7cd19dcf5a31b4eb478416694e965222')
+
+    def tag(self) -> str:
+        return self.value[0]
+
+    def sha(self) -> str:
+        return self.value[1]
+
+
+class Tests(unittest.TestCase):
+
+    GIT_DIR = 'clone-for-test'
+    ORIGIN_URL = 'https://github.com/Mbed-TLS/mbedtls'
+    SCRIPT_NAME = 'mbedtls-rewrite-branch-style'
+
+    script = None #type: Optional[str]
+    git_main_dir = None #type: Optional[str]
+
+
+    @classmethod
+    def call_git(cls, args: List[str], **kwargs) -> None:
+        assert cls.git_main_dir is not None
+        subprocess.check_call(['git', '-C', cls.git_main_dir] + args,
+                              **kwargs)
+
+    @classmethod
+    def check_git(cls, args: List[str], **kwargs) -> bool:
+        try:
+            cls.call_git(args, **kwargs)
+            return True
+        except subprocess.CalledProcessError as cpe:
+            if cpe.returncode == 1:
+                return False
+            raise
+
+    @classmethod
+    def git_output(cls, args: List[str], **kwargs) -> str:
+        assert cls.git_main_dir is not None
+        return subprocess.check_output(['git', '-C', cls.git_main_dir] + args,
+                                       universal_newlines=True,
+                                       **kwargs)
+
+    @classmethod
+    def git_line(cls, args: List[str], **kwargs) -> str:
+        return cls.git_output(args, **kwargs).rstrip('\n')
+
+    @classmethod
+    def git_lines(cls, args: List[str], **kwargs) -> List[str]:
+        return cls.git_output(args, **kwargs).splitlines()
+
+    @classmethod
+    def git_sha(cls, ref: str) -> Optional[str]:
+        """The sha for a Git revision, or None if there is no such revision."""
+        try:
+            return cls.git_line(['rev-parse', ref])
+        except subprocess.CalledProcessError as cpe:
+            return None
+
+    @classmethod
+    def git_head(cls, path: str) -> Optional[str]:
+        """The sha of the head in a Git worktree."""
+        output = subprocess.check_output(['git', '-C', path,
+                                          'rev-parse', 'HEAD'],
+                                         universal_newlines=True)
+        return output.rstrip('\n')
+
+    @classmethod
+    def git_delete_branch(cls, branch: str) -> None:
+        """Delete branch if it exists. Do nothing if it doesn't exist."""
+        ref = 'refs/heads/' + branch
+        if cls.check_git(['show-ref', '--quiet', '--verify', ref]):
+            cls.call_git(['branch', '--quiet', '--delete', '--force', branch])
+
+    @classmethod
+    def create_git_clone(cls) -> None:
+        """Create the git clone used by the tests."""
+        assert cls.git_main_dir is not None
+        subprocess.check_call(['git', 'clone',
+                               '--no-tags', '--single-branch',
+                               '--branch=master',
+                               cls.ORIGIN_URL,
+                               cls.git_main_dir])
+
+    @classmethod
+    def update_git_clone(cls) -> None:
+        """Set up the existing git clone with what the tests needs.
+
+        This method is destructive. It may create, update or remove branches,
+        tags, worktrees, worktree contents, etc.
+        """
+        cls.call_git(['fetch', '--quiet', 'origin'] +
+                     [commit.sha() for commit in TestCommits])
+        for commit in TestCommits:
+            cls.call_git(['tag', '--force', commit.tag(), commit.sha()])
+        # TODO: when guessing the target branch, we need the
+        # features/new-code-style/* branches. But they'll get out of synch
+        # of the snapshot commit IDs hard-coded in these tests.
+        cls.call_git(['fetch', '--quiet', 'origin',
+                      'refs/heads/features/new-code-style/*:refs/remotes/origin/features/new-code-style/*'])
+        cls.call_git(['fetch', '--quiet', 'origin',
+                      'refs/tags/features/new-code-style/*:refs/remotes/origin/features/new-code-style/*'])
+        # Make sure the main worktree doesn't have a branch checked out that
+        # might interfere with some of the tests.
+        cls.call_git(['checkout', '--detach'])
+
+    @contextlib.contextmanager
+    def temp_worktree(self, **kwargs) -> Iterator[temp_git_worktree]:
+        assert self.git_main_dir is not None
+        path = os.path.join(os.path.dirname(self.git_main_dir),
+                            'worktree-for-test-' + self.id())
+        with temp_git_worktree(self.git_main_dir, path, **kwargs) as worktree:
+            yield worktree
+
+    def assert_same_history(self,
+                            common_ancestor: str,
+                            branch1: str, branch2: str) -> None:
+        """Assert that branch1 and branch2 consist of common_ancestor followed by similar commits.
+
+        Similar commits are defined as equal according to `git range-diff`:
+        they must have the same content and description, but may have different
+        metadata (in particular, committer name and date).
+        """
+        # merge_base = self.git_line(['merge-base', branch1, branch2])
+        # wanted_merge_base = self.git_line(['rev-parse', common_ancestor])
+        # self.assertEqual(merge_base, wanted_merge_base)
+        if not self.check_git(['merge-base', '--is-ancestor',
+                               common_ancestor, branch1]):
+            self.fail('{} ({}) is not an ancestor of {} ({})'
+                      .format(common_ancestor, self.git_sha(common_ancestor),
+                              branch1, self.git_sha(branch1)))
+        if not self.check_git(['merge-base', '--is-ancestor',
+                               common_ancestor, branch2]):
+            self.fail('{} ({}) is not an ancestor of {} ({})'
+                      .format(common_ancestor, self.git_sha(common_ancestor),
+                              branch2, self.git_sha(branch2)))
+        range_diff = self.git_lines(['range-diff', '--no-color',
+                                     common_ancestor, branch1, branch2])
+        for line in range_diff:
+            self.assertRegex(line, r'\A[0-9]+: *[0-9a-f]+ = ')
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        my_dir = os.path.dirname(__file__)
+        cls.script = os.path.abspath(
+            os.getenv('SCRIPT_PATH',
+                      os.path.join(my_dir, os.pardir, 'bin', cls.SCRIPT_NAME)))
+        cls.git_main_dir = os.path.abspath(
+            os.getenv('TMP_GIT_DIR',
+                      os.path.join(my_dir, cls.GIT_DIR)))
+        assert cls.git_main_dir is not None
+        if not os.path.exists(cls.git_main_dir):
+            cls.create_git_clone()
+        cls.update_git_clone()
+
+    def temp_branch(self, name: str) -> str:
+        """A name for a temporary branch.
+
+        temp_branch(name) returns the same branch name when passed the same
+        name parameter and called from the same test case, and distinct
+        branch names otherwise.
+
+        The branch is guaranteed not to exist when the test starts,
+        and will be removed when the test ends.
+        """
+        return 'tmp/{}/{}'.format(self.id(), name)
+
+    def delete_temporary_branches(self, case_id: str) -> None:
+        branches = self.git_lines(['for-each-ref', '--format=%(refname:short)',
+                                   'tmp/{}/*'.format(case_id)])
+        if branches:
+            self.call_git(['branch', '--quiet', '--delete', '--force'] +
+                          branches)
+
+    def setUp(self) -> None:
+        self.delete_temporary_branches(self.id())
+
+    def tearDown(self) -> None:
+        self.delete_temporary_branches(self.id())
+
+    def run_script(
+            self,
+            args: List[str],
+            cwd: Optional[str] = None
+    ) -> subprocess.CompletedProcess:
+        """Run the script with the given arguments."""
+        assert self.script is not None
+        if cwd is None:
+            cwd = self.git_main_dir
+        return subprocess.run([self.script] + args,
+                              check=False,
+                              cwd=cwd,
+                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                              universal_newlines=True)
+
+    def test_help(self) -> None:
+        cp = self.run_script(['--help'])
+        self.assertEqual(cp.returncode, 0)
+        self.assertIn('Rewrite', cp.stdout)
+        self.assertIn('--verbose', cp.stdout)
+        self.assertEqual(cp.stderr, '')
+
+    def test_unknown_option(self) -> None:
+        cp = self.run_script(['--barf'])
+        self.assertEqual(cp.returncode, 2)
+        self.assertEqual(cp.stdout, '')
+        self.assertNotEqual(cp.stderr, '')
+
+    def test_detached_6863(self) -> None:
+        new_branch = self.temp_branch('new')
+        with self.temp_worktree(head='pull/6863') as worktree:
+            cp = self.run_script(['-v', '--backup-branch=',
+                                  '--new-branch', new_branch],
+                                 cwd=worktree.path)
+            self.assertEqual(cp.returncode, 0)
+            self.assert_same_history('origin/features/new-code-style/development~1',
+                                     'origin/features/new-code-style/test/new/6863',
+                                     new_branch)
+
+    def test_updating_6863(self) -> None:
+        temp_branch = self.temp_branch('work')
+        with self.temp_worktree(branch=temp_branch, head='pull/6863') as worktree:
+            cp = self.run_script(['-v', '--backup-branch='],
+                                 cwd=worktree.path)
+            self.assertEqual(cp.returncode, 0)
+            self.assert_same_history('origin/features/new-code-style/development~1',
+                                     'origin/features/new-code-style/test/new/6863',
+                                     temp_branch)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -73,6 +73,7 @@ class TestCommits(enum.Enum):
     # Snapshots of branches and pull requests used by the tests.
     pr_6784 = ('pull/6784', 'ea8c88fcbb85917b7e323c016f9ba47bbd55f930')
     pr_6863 = ('pull/6863', 'e79fb03b7cd19dcf5a31b4eb478416694e965222')
+    pr_6866 = ('pull/6866', 'ff7d7c3a9a4c5afa9dda0c3e7a8c0f3211b0a366')
 
     def tag(self) -> str:
         return self.value[0]
@@ -288,6 +289,17 @@ class Tests(unittest.TestCase):
             self.assertEqual(cp.returncode, 0)
             self.assert_same_history('origin/features/new-code-style/development~1',
                                      'origin/features/new-code-style/test/new/6863',
+                                     new_branch)
+
+    def test_detached_6866(self) -> None:
+        new_branch = self.temp_branch('new')
+        with self.temp_worktree(head='pull/6866') as worktree:
+            cp = self.run_script(['-v', '--backup-branch=',
+                                  '--new-branch', new_branch],
+                                 cwd=worktree.path)
+            self.assertEqual(cp.returncode, 0)
+            self.assert_same_history('origin/features/new-code-style/development~1',
+                                     'origin/features/new-code-style/test/new/6866',
                                      new_branch)
 
     def test_updating_6863(self) -> None:

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -177,7 +177,7 @@ class Tests(unittest.TestCase):
                       'refs/tags/features/new-code-style/*:refs/remotes/origin/features/new-code-style/*'])
         # Make sure the main worktree doesn't have a branch checked out that
         # might interfere with some of the tests.
-        cls.call_git(['checkout', '--detach'])
+        cls.call_git(['checkout', '--quiet', '--detach'])
 
     @contextlib.contextmanager
     def temp_worktree(self, **kwargs) -> Iterator[temp_git_worktree]:

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -169,9 +169,9 @@ class Tests(unittest.TestCase):
         # TODO: when guessing the target branch, we need the
         # features/new-code-style/* branches. But they'll get out of synch
         # of the snapshot commit IDs hard-coded in these tests.
-        cls.call_git(['fetch', '--quiet', 'origin',
+        cls.call_git(['fetch', '--quiet', '--force', 'origin',
                       'refs/heads/features/new-code-style/*:refs/remotes/origin/features/new-code-style/*'])
-        cls.call_git(['fetch', '--quiet', 'origin',
+        cls.call_git(['fetch', '--quiet', '--force', 'origin',
                       'refs/tags/features/new-code-style/*:refs/remotes/origin/features/new-code-style/*'])
         # Make sure the main worktree doesn't have a branch checked out that
         # might interfere with some of the tests.


### PR DESCRIPTION
A standalone script to rewrite a branch of Mbed TLS on top of the coding style change. Addresses https://github.com/Mbed-TLS/mbedtls/issues/6353. Based on the design discussed in Slack ([1](https://arm-ce.slack.com/archives/C01CC4Y1T1P/p1671703286916489), [2](https://arm-ce.slack.com/archives/C01CC4Y1T1P/p1671723166653789?thread_ts=1671704254.473679&cid=C01CC4Y1T1P) (private links)).

This is an almost complete rewrite of https://github.com/Mbed-TLS/mbedtls/pull/6626. I used it as a guide, but changed several aspects:

* Completely standalone, don't rely on `code_style.py`. Reasoning: we can get `code_style.py` from the code style switch commit, but that would remain hard-coded forever. Or we can get `code_style.py` from the same place as the branch rewrite script, but that means users need a separate checkout of mbedtls.
* Use worktrees instead of disrupting the current tree. This reduces the risk of seriously messing up if something goes wrong.
* Don't create or modify any branch names until everything is done. This way there's less to clean up if something goes wrong.
* Guesses the branch to rewrite onto (currently `features/new-code-style/{development,mbedtls-2.28}`, to be changed once they become official).
* By default, rewrites the current branch on success.
* Use exceptions for errors.

Missing compared to https://github.com/Mbed-TLS/mbedtls/pull/6626:

* User-friendly messages on errors. Should be improved for MVP.

**So far, there is error detection but not error recovery or user-friendly error messages. Please use verbose mode (`-v`) when testing.**