### PR TITLE
Branch rewrite script: handle deleted files

### DIFF
--- a/kb/how-to/rewrite-branch-for-coding-style.md
+++ b/kb/how-to/rewrite-branch-for-coding-style.md
@@ -123,12 +123,6 @@ The rewrite script was written for simple cases of branches that fork from an of
 
 Workaround: manually rebase on top of the last commit before the style change. If there are no merges left in your branch, you can use the script to do the rest of the work. Otherwise you'll need to do a manual merge instead of rewriting your branch.
 
-### Deleted files
-
-The rewrite script may not work if a commit deletes a restyled file.
-
-Workaround: wait for a fix.
-
 ## Troubleshooting
 
 ### If something goes wrong

--- a/kb/how-to/rewrite-branch-for-coding-style.md
+++ b/kb/how-to/rewrite-branch-for-coding-style.md
@@ -125,7 +125,7 @@ Workaround: manually rebase on top of the last commit before the style change. I
 
 ### Deleted files
 
-The rewrite script may not work if a commit deletes a file.
+The rewrite script may not work if a commit deletes a restyled file.
 
 Workaround: wait for a fix.
 

--- a/kb/how-to/rewrite-branch-for-coding-style.md
+++ b/kb/how-to/rewrite-branch-for-coding-style.md
@@ -129,12 +129,6 @@ The rewrite script may not work if a commit deletes a file.
 
 Workaround: wait for a fix.
 
-### Windows
-
-Git detection may fail on Windows.
-
-Workaround: wait for a fix or use another Git implementation or another operating system.
-
 ## Troubleshooting
 
 ### If something goes wrong

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -22,6 +22,7 @@ Invoke this script from a Git working directory with a branch of Mbed TLS.
 import argparse
 import os
 import pathlib
+import re
 import subprocess
 import sys
 from typing import List, Optional
@@ -172,8 +173,17 @@ class BranchRewriter:
         ok = True
         # 'git worktree remove' was added in Git 2.17.0. It's the most
         # recent Git feature that we need.
-        output = self.run_git(['worktree', '--help'])
-        if 'git worktree remove' not in output:
+        try:
+            output = self.run_git(['--version'])
+            self.info('Found git: ' + output.strip())
+        except subprocess.CalledProcessError:
+            output = ''
+        m = re.search(r'([0-9]+)\.([0-9]+)', output)
+        if not m:
+            self.log_error('No working git command found')
+            return False
+        version = tuple(int(s) for s in m.groups())
+        if version < (2, 17):
             self.log_error('Your version of Git is too old. This script needs Git >=2.17.0.')
             ok = False
         # Check that we're in a Git working directory. Remember its path.

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -493,7 +493,9 @@ class CodeStyleBranchRewriter(MbedTLSBranchRewriter):
         # cherry-picked commit, but might mess up modified files. Then
         # we override the content of modified files, and finally we restyle
         # files that need restyling.
-        self.run_git(['cherry-pick', '-Xtheirs', '--allow-empty', new_commit])
+        self.run_git(['cherry-pick', '-Xtheirs',
+                      '--allow-empty', '--keep-redundant-commits',
+                      new_commit])
         self.info('{} has been cherry-picked as {}', new_commit, self.head_sha())
         # Restyle the code to the new style. Only restyle changed files.
         changed_files = self.changed_files_in_commit('HEAD')

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -312,8 +312,8 @@ class MbedTLSBranchRewriter(BranchRewriter):
     """Tools to rebase and rewrite a branch of Mbed TLS."""
 
     UPSTREAM_URLS = frozenset(map(lambda s: s.lower(), [
-        'git@github.com:ARMmbed/mbedtls.git',
-        'git@github.com:Mbed-TLS/mbedtls.git',
+        'git@github.com:ARMmbed/mbedtls',
+        'git@github.com:Mbed-TLS/mbedtls',
         'https://github.com/ARMmbed/mbedtls',
         'https://github.com/Mbed-TLS/mbedtls',
     ]))
@@ -331,7 +331,11 @@ class MbedTLSBranchRewriter(BranchRewriter):
         for remote in remotes:
             (name, rest) = remote.split('\t', 2)
             (url, rest) = rest.split(' ', 1)
-            if url.lower() in self.UPSTREAM_URLS:
+            normalized_url = url.lower()
+            if normalized_url.endswith('.git'):
+                normalized_url = normalized_url[:-4]
+            print(normalized_url)
+            if normalized_url in self.UPSTREAM_URLS:
                 self.info('Found upstream remote: {}', name)
                 self.upstream_remote = name
                 return

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -25,7 +25,7 @@ import pathlib
 import re
 import subprocess
 import sys
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 
 class BranchRewriter:
@@ -413,8 +413,37 @@ class CodeStyleBranchRewriter(MbedTLSBranchRewriter):
         self.info('Switch commit: {}', sha)
         return sha
 
-    def changed_files_in_commit(self, revision: str) -> List[str]:
-        """The list of files changed or added in the given revision."""
+    @staticmethod
+    def split_name_status_line(
+            line: str
+    ) -> Tuple[str, Optional[str], Optional[str]]:
+        """Helper for file_breakdown. Formats one list element from the diff-status line."""
+        columns = line.split('\t')
+        status = columns[0][0]
+        if status == 'A':
+            names = (None, columns[1]) #type: Tuple[Optional[str], Optional[str]]
+        elif status == 'M':
+            names = (columns[1], columns[1])
+        elif status == 'D':
+            names = (columns[1], None)
+        elif status == 'R':
+            names = (columns[1], columns[2])
+        else:
+            raise ValueError('name-status not supported: ' + line)
+        return (status, names[0], names[1])
+
+    def file_breakdown(
+            self, revision: str
+    ) -> List[Tuple[str, Optional[str], Optional[str]]]:
+        """The list of files affected by a revision, and how.
+
+        Each element of the list is a tuple (letter, old_name, new_name) where:
+        * letter is the diff-filter indicator ('A'=added, 'M'=modified,
+          'D'=deleted, 'R'=renamed).
+        * old_name is the file's old name (None if added).
+        * new_name is the file's new name (None if deleted, identical to
+          old_name if modified)
+        """
         # The git command prints a list of the form:
         #   * 'A\t{filename}' for an added file
         #   * 'M\t{filename}' for a modified file
@@ -422,10 +451,23 @@ class CodeStyleBranchRewriter(MbedTLSBranchRewriter):
         #   * 'R{confidence}\t{old_name}\t{new_name}' for a renamed file
         lines = self.get_git_lines(['show', '--format=', '--name-status',
                                     revision])
-        filenames = [line.rsplit('\t', 1)[-1]
-                     for line in lines
-                     if line[0] != 'D'] # skip deleted files
-        return filenames
+        return [self.split_name_status_line(line) for line in lines]
+
+    def changed_files_in_commit(self, revision: str) -> List[str]:
+        """The list of files changed or added in the given revision.
+
+        This includes the new name of renamed files.
+        """
+        return [b[2] for b in self.file_breakdown(revision)
+                if b[2] is not None]
+
+    def deleted_files_in_commit(self, revision: str) -> List[str]:
+        """The list of files deleted in the given revision.
+
+        This does not include renamed files.
+        """
+        return [b[1] for b in self.file_breakdown(revision)
+                if b[1] is not None and b[2] is None]
 
     @staticmethod
     def is_c_file(path: pathlib.PurePath) -> bool:
@@ -489,21 +531,27 @@ class CodeStyleBranchRewriter(MbedTLSBranchRewriter):
         # strategy, but that seems hard (especially since we do want to
         # tweak the content even if there are no merge conflicts). So we
         # pick some method of resolving the conflict automatically
-        # that ensures that added and removed files are according to the
-        # cherry-picked commit, but might mess up modified files. Then
-        # we override the content of modified files, and finally we restyle
-        # files that need restyling.
+        # that ensures that there are no conflicts, then we override the
+        # commit's content. To ensure there aren't modify/delete conflicts
+        # when the new commit deletes a file (which no built-in strategy
+        # achieves), first forcibly delete such files.
+        deleted_files = self.deleted_files_in_commit(new_commit)
+        if deleted_files:
+            self.run_git(['rm', '--quiet', '--'] + deleted_files)
         self.run_git(['cherry-pick', '-Xtheirs',
-                      '--allow-empty', '--keep-redundant-commits',
+                      '--allow-empty', '--keep-redundant-commits', '--no-commit',
                       new_commit])
+        self.run_git(['commit', '--quiet', '--no-edit',
+                      '--allow-empty', '--allow-empty-message',
+                      '--reuse-message', new_commit])
         self.info('{} has been cherry-picked as {}', new_commit, self.head_sha())
-        # Restyle the code to the new style. Only restyle changed files.
-        changed_files = self.changed_files_in_commit('HEAD')
+        changed_files = self.changed_files_in_commit(new_commit)
         if changed_files:
             self.run_git(['reset', '--quiet', new_commit, '--'] + changed_files)
             self.run_git(['commit', '--amend', '--no-edit', '--allow-empty'])
             self.run_git(['reset', '--quiet', '--hard'])
             self.info('{} has been amended to {}', new_commit, self.head_sha())
+            # Restyle the code to the new style. Only restyle changed files.
             files_to_restyle = self.filter_styled_files(changed_files)
             if files_to_restyle:
                 self.restyle_files(files_to_restyle)

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -86,6 +86,8 @@ class BranchRewriter:
         Ignore trailing empty lines, but preserve leading and inner empty lines.
         """
         output = self.run_git(git_cmd, **kwargs)
+        if not output:
+            return []
         return output.rstrip('\n').split('\n')
 
     def head_sha(self) -> str:

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -180,11 +180,11 @@ class BranchRewriter:
             output = ''
         m = re.search(r'([0-9]+)\.([0-9]+)', output)
         if not m:
-            self.log_error('No working git command found')
+            self.log_error('! No working git command found')
             return False
         version = tuple(int(s) for s in m.groups())
         if version < (2, 17):
-            self.log_error('Your version of Git is too old. This script needs Git >=2.17.0.')
+            self.log_error('! Your version of Git is too old. This script needs Git >=2.17.0.')
             ok = False
         # Check that we're in a Git working directory. Remember its path.
         output = self.run_git(['rev-parse', '--show-toplevel'])
@@ -370,7 +370,7 @@ class CodeStyleBranchRewriter(MbedTLSBranchRewriter):
                                          universal_newlines=True)
         self.info('Found uncrustify: {}', output.strip())
         if self.UNCRUSTIFY_SUPPORTED_VERSION not in output:
-            self.log_error('Unsupported version of uncrustify. This script needs {}.',
+            self.log_error('! Unsupported version of uncrustify. This script needs {}.',
                            self.UNCRUSTIFY_SUPPORTED_VERSION)
             ok = False
         return ok

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -324,6 +324,8 @@ class Result(Utilities):
     def test_6890(self) -> None:
         self.run_on_branch('6890')
 
+    def test_rename_delete(self) -> None:
+        self.run_on_branch('rename-delete')
 
 class Detection(Utilities):
     """Test target branch detection."""

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -309,11 +309,20 @@ class Result(Utilities):
     def test_6863(self) -> None:
         self.run_on_branch('6863')
 
+    def test_6882(self) -> None:
+        self.run_on_branch('6882')
+
+    def test_6883(self) -> None:
+        self.run_on_branch('6883')
+
     def test_6888(self) -> None:
         self.run_on_branch('6888')
 
     def test_6889(self) -> None:
         self.run_on_branch('6889')
+
+    def test_6890(self) -> None:
+        self.run_on_branch('6890')
 
 
 class Detection(Utilities):


### PR DESCRIPTION
Fix a failure of the branch rewrite script when a C file is deleted: this caused a modify/delete confict during cherry-pick.

I use an alternative approach compared with #71 which avoids creating an error situation where we ignore an error, but aren't sure that the error we're ignoring is the error we were expecting.

This pull request includes the non-controversial changes in https://github.com/Mbed-TLS/mbedtls-docs/pull/73 because I haven't bothered isolating the tests and managing the trivial add/add conflicts that rebasing would cause. The first new commit is "Fix handling of commits that delete a C file".
