### PR TITLE
Branch rewriting: ship it!

### DIFF
--- a/kb/how-to/rewrite-branch-for-coding-style.md
+++ b/kb/how-to/rewrite-branch-for-coding-style.md
@@ -144,6 +144,15 @@ $ git worktree list | grep /tmp-
 ```
 Use `git worktree remove -f /home/me/work/tmp-mybranch-1234` to remove the worktree.
 
+### Git rebase fails
+
+The rewrite script starts by rebasing the given branch on top of the last upstream commit before the code style change. If there is a conflict, the script fails:
+```
+subprocess.CalledProcessError: Command '['git', 'rebase', '449bd8303eed8164b83682d2ce028dca0e49b1fa~1']' returned non-zero exit status 1.
+```
+
+In this case, please do the rebase manually and resolve the conflicts, then run the rewrite script again.
+
 ### Wrong version of uncrustify
 
 If you see the message

--- a/tools/bin/mbedtls-rewrite-branch-style
+++ b/tools/bin/mbedtls-rewrite-branch-style
@@ -358,9 +358,13 @@ class CodeStyleBranchRewriter(MbedTLSBranchRewriter):
         pathlib.PurePath('programs/test/query_config.c'),
     ])
 
-    # To be updated once the new code style becomes official,
-    # or possibly change to tags instead of branches.
-    TARGET_BRANCH_PREFIX = 'features/new-code-style/'
+    # The code style change commit, or a commit soon after it.
+    TARGET_BRANCHES = {
+        'development': 'c848d226bf2355ba54ab95cca15839557cf935c0',
+        'mbedtls-2.28': 'b9e56fb5606225b62a0eaf4a90339d1e5739e4c1',
+    }
+    # For branch detection: a commit soon after mbedtls-2.28 LTS diverged
+    MBEDTLS_2_28_0 = '8b3f26a5ac38d4fdccbc5c5366229f3e01dafcc0'
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
@@ -392,17 +396,21 @@ class CodeStyleBranchRewriter(MbedTLSBranchRewriter):
         """
         if self.target_branch is not None:
             return
-        self.guess_upstream_remote()
         self.info('Guessing target branch...')
         if self.check_git(['merge-base', '--is-ancestor',
-                           'mbedtls-2.28.0', 'HEAD']):
-            branch = 'mbedtls-2.28'
+                           self.MBEDTLS_2_28_0, 'HEAD']):
+            branch_name = 'mbedtls-2.28'
         else:
-            branch = 'development'
-        self.target_branch = '{}/{}{}'.format(self.upstream_remote,
-                                              self.TARGET_BRANCH_PREFIX,
-                                              branch)
-        self.info('Guessed target branch: {}', self.target_branch)
+            branch_name = 'development'
+        commit_id = self.TARGET_BRANCHES[branch_name]
+        if not self.check_git(['rev-parse', commit_id],
+                              stdout=subprocess.DEVNULL):
+            self.log_error('Commit ID {} not found for the guessed target branch {}.')
+            self.log_error('Please run "git fetch" on the upstream mbedtls repository.')
+            raise Exception('Guessed target commit {} not found'
+                            .format(commit_id))
+        self.target_branch = commit_id
+        self.info('Guessed target branch: {} = {}', branch_name, commit_id)
 
     def find_switch_commit(self) -> str:
         """Return the sha of the commit with the code style switch."""

--- a/tools/test/mbedtls-test-rewrite-branch-style
+++ b/tools/test/mbedtls-test-rewrite-branch-style
@@ -341,11 +341,11 @@ class Detection(Utilities):
             self.assertRegex(cp.stderr,
                              r'Guessed target branch: (\S+/)?' + expected_target)
 
-    def test_6888(self) -> None:
-        self.run_on_branch('6888', 'development')
+    def test_6802(self) -> None:
+        self.run_on_branch('6802', 'development')
 
-    def test_6889(self) -> None:
-        self.run_on_branch('6889', 'mbedtls-2.28')
+    def test_6844(self) -> None:
+        self.run_on_branch('6844', 'mbedtls-2.28')
 
 
 class Options(Utilities):


### PR DESCRIPTION
Replace preview branch names by hard-coded official commits (https://github.com/Mbed-TLS/mbedtls/pull/6907 and https://github.com/Mbed-TLS/mbedtls/pull/6908). This eliminates the need to detect remotes.

Also update the branch detection tests, which started failing when the corresponding pull requests were made. This won't be a problem going forward since we aren't going to merge more branches.
