### PR TITLE
Link to the API documentation

### DIFF
--- a/index.md
+++ b/index.md
@@ -26,6 +26,7 @@ maxdepth: 2
 caption: Contents
 ---
 getting_started/index.md
+API Reference <https://mbed-tls.readthedocs.io/projects/api>
 reviews/index.md
 roadmap.md
 architecture/proposed/long-term-plans.md


### PR DESCRIPTION
The API documentation is now available on [read the docs](https://mbed-tls.readthedocs.io/projects/api/en/latest), so link to it from the main documentation.