### PR TITLE
Remove unnecessary "Mbed TLS" from Getting Started heading

### DIFF
--- a/getting_started/index.md
+++ b/getting_started/index.md
@@ -1,4 +1,4 @@
-# Getting started with Mbed TLS
+# Getting Started
 ```{toctree}
 ---
 glob:


### PR DESCRIPTION
We know which project's documentation we are in because of the site title. Repeating the project name is redundant and a little jarring.

Shorten the titles to be more intuitive.