### PR TITLE
Correct CMake build syntax in building guide

### DIFF
--- a/getting_started/building.md
+++ b/getting_started/building.md
@@ -72,7 +72,7 @@ The following modes are supported:
 
 For debug mode, enter at the command line:
 ```sh
-cmake -D CMAKE_BUILD_TYPE:Debug .
+cmake -D CMAKE_BUILD_TYPE=Debug .
 ```
 To list other available CMake options, use:
 ```sh


### PR DESCRIPTION
CMake uses '=' for assignment, not ':'

Correct the syntax to prevent users from being tripped up.