### PR TITLE
mtest - fall back to clang if armclang unavailable for -S

### DIFF
--- a/tools/bin/mtest
+++ b/tools/bin/mtest
@@ -764,7 +764,12 @@ Build targets: build the library by default, or files (e.g. aes.o), programs (e.
         args.compilers = [ MEMSAN_CC ]
 
     if args.size_tfm:
-        if not args.compilers: args.compilers = [ SIZE_TFM_COMPILER ]
+        if not args.compilers:
+            if shutil.which(SIZE_TFM_COMPILER) is not None:
+                args.compilers = [ SIZE_TFM_COMPILER ]
+            else:
+                print("warning: could not find armclang, falling back to clang")
+                args.compilers = [ "clang" ]
         args.size = True
 
     if not args.compilers:

--- a/tools/bin/mtest
+++ b/tools/bin/mtest
@@ -61,7 +61,7 @@ ASAN_CFLAGS   = "-fsanitize=address -fno-common -fsanitize=undefined -fno-saniti
 ASAN_LDFLAGS  = ASAN_CFLAGS
 
 WARNING_FLAGS = {
-    "clang": "-Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths",
+    "clang": "-Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wasm-operand-widths -Wunreachable-code",
     "gcc"  : "-Werror -Wall -Wextra -Wwrite-strings -Wpointer-arith -Wimplicit-fallthrough -Wshadow -Wvla -Wformat=2 -Wno-format-nonliteral -Wshadow -Wformat-signedness -Wformat-overflow=2 -Wformat-truncation -Wlogical-op"
 }
 WARNING_FLAGS["arm-none-eabi-gcc"] = WARNING_FLAGS["gcc"]


### PR DESCRIPTION
When running `mtest -S`, fall back to clang if arm clang is not available.

Enable unreachable code warning for clang.