### PR TITLE
Mtest - Disable SPM for TF-M config

### DIFF
--- a/tools/bin/mtest
+++ b/tools/bin/mtest
@@ -440,12 +440,15 @@ def configure_options(target):
 
     for config in bulk_options:
         if config == COPY_TFM_CONFIG:
+            # older versions of this config file need SPM to be disabled
+            disable_spm = True
             # special flag to copy both TF-M config files - these have a couple of possible locations
             for mc, cc in TFM_CONFIG_FILES:
                 if os.path.exists(f"{ROOT}/configs/{mc}") and (cc is None or os.path.exists(f"{ROOT}/configs/{cc}")):
                     if mc == TFM_CONFIG_FILES[0][0]:
                         # latest TF-M config file unsets this, so set it again
                         set_no_platform_entropy = True
+                        disable_spm = False # not needed with latest version
                     for c, dest in zip([mc, cc], [CONFIG_FILE, CRYPTO_CONFIG_FILE]):
                         if c is not None:
                             log(f"cp configs/{c} {dest[len(ROOT) + 1:]}")
@@ -454,8 +457,6 @@ def configure_options(target):
             else:
                 # for looking at old checkouts where these configs were not in the tree, fetch from
                 # date they were first created instead
-                # also disable MBEDTLS_PSA_CRYPTO_SPM is required to get it to build
-                disable_spm = True
                 for config, dest in zip(TFM_CONFIG_FILES[-1], [CONFIG_FILE, CRYPTO_CONFIG_FILE]):
                     log(f"git show 2f1ae5a86ebd67faa50c3983b4567656c2234674:configs/{config} > {dest[len(ROOT) + 1:]}")
                     output, _ = subrun(["git", "show", "origin/development:configs/" + config], silent=True)


### PR DESCRIPTION
Disable SPM in older versions of the tf-m config file