### PR TITLE
Migrate to new RTD redirect format

### DIFF
--- a/redirects.yaml
+++ b/redirects.yaml
@@ -5,20 +5,22 @@
 # redirects - changes to this file are only applied when they are merged
 # into the main branch.
 
-- type: sphinx_htmldir
+- type: html_to_clean_url
+  from_url: /
+  to_url: /
 
 - type: page
-  from_url: /tech-updates/security-advisories/
+  from_url: /tech-updates/security-advisories
   to_url: /security-advisories/
 
 - type: page
-  from_url: /security-advisories/security-advisories/
+  from_url: /security-advisories/security-advisories
   to_url: /security-advisories/
 
-- type: exact
-  from_url: /en/latest/security-advisories/advisories/$rest
-  to_url: /en/latest/security-advisories/
+- type: page
+  from_url: /security-advisories/advisories/*
+  to_url: /security-advisories/:splat
 
 - type: page
-  from_url: /roadmap/
+  from_url: /roadmap
   to_url: /project/roadmap/


### PR DESCRIPTION
Migrate to the new redirect format introduced by ReadTheDocs in readthedocs/readthedocs.org#10881

The redirect format is described in full [here](https://docs.readthedocs.io/en/stable/user-defined-redirects.html)

The wildcard redirect is broken at the moment [due to faulty infinite redirect detection on the ReadTheDocs side](https://github.com/readthedocs/readthedocs.org/blob/13ab601b73b4a3b3251789eef3a564cdd041eb85/readthedocs/redirects/models.py#L262-L276).