### PR TITLE
Bring over remaining phabricator content

### DIFF
--- a/index.md
+++ b/index.md
@@ -27,7 +27,7 @@ For questions and discussions:
 
 Security vulnerabilities:
 
-Please see our [process for reporting vulnerabilities](project/vulnerabilities.md).
+* Please see our [process for reporting vulnerabilities](project/vulnerabilities.md).
 
 ```{toctree}
 ---

--- a/index.md
+++ b/index.md
@@ -25,6 +25,10 @@ For questions and discussions:
 * [The Mbed TLS mailing list](https://lists.trustedfirmware.org/mailman3/lists/mbed-tls.lists.trustedfirmware.org/).
 * The `#mbed-tls` channel on the [TrustedFirmware Discord server](https://discord.com/channels/1106321706588577904/1144310640341700739) - use the [invite link](https://discord.gg/5PpXhvda5p) to join.
 
+Security vulnerabilities:
+
+Please see our [process for reporting vulnerabilities](project/vulnerabilities.md).
+
 ```{toctree}
 ---
 maxdepth: 2

--- a/kb/testing/index.md
+++ b/kb/testing/index.md
@@ -1,0 +1,8 @@
+# Testing Mbed TLS
+```{toctree}
+---
+glob:
+maxdepth: 1
+---
+*
+```

--- a/kb/testing/testing-ci.md
+++ b/kb/testing/testing-ci.md
@@ -104,4 +104,4 @@ The tests attempt to establish an IPv6 connection to the local host. This is opt
 
 ### Docker environment
 
-A Dockerfile is provided in [tests/docker](https://github.com/ARMmbed/mbedtls/tree/development/tests/docker).
+A Dockerfile is provided in [tests/docker](https://github.com/Mbed-TLS/mbedtls/tree/development/tests/docker).

--- a/kb/testing/testing-ci.md
+++ b/kb/testing/testing-ci.md
@@ -101,7 +101,3 @@ ln -s x86_64-linux-gnu/asm /usr/include/asm
 ### Notes about networking
 
 The tests attempt to establish an IPv6 connection to the local host. This is optional, and will be skipped if IPv6 is not available. However, if IPv6 is possible but IPv6 connections to localhost are blocked by a firewall, the test will fail.
-
-### Docker environment
-
-A Dockerfile is provided in [tests/docker](https://github.com/Mbed-TLS/mbedtls/tree/development/tests/docker).

--- a/kb/testing/testing-ci.md
+++ b/kb/testing/testing-ci.md
@@ -1,0 +1,107 @@
+# Mbed TLS CI
+
+All code that is included in Mbed TLS must be contributed in the form of [[https://github.com/Mbed-TLS/mbedtls/pulls | pull requests on GitHub]] and undergoes some automated testing. This page describes the continuous integration jobs that run on every pull request.
+
+## DCO
+
+This job checks that all commits have a `Signed-off-by:` line. The presence of this line indicates that the author of the commit certifies that the commit is covered by the [[https://github.com/Mbed-TLS/mbedtls/blob/development/dco.txt | Developer Certificate of Origin]] and contributed according to the [[https://github.com/Mbed-TLS/mbedtls/blob/development/README.md#License | project license]].
+
+All commits must have such a line, otherwise the commit cannot be accepted for legal reasons. As a temporary exception, commits from Arm employees or from other contributors who already have a contributor license agreement (CLA) can still be accepted, but please include a `Signed-off-by:` line in any new work.
+
+If the DCO job fails, please reword all commit messages that are missing a `Signed-off-by:` line. If you have multiple commit messages to rewrite, [[https://stackoverflow.com/questions/25570947/how-to-use-git-interactive-rebase-for-signing-off-a-series-of-commits | How to use git interactive rebase for signing off a series of commits]] may help.
+
+## PR-head and PR-merge jobs
+
+The PR-//NNN//-head and PR-//NNN//-merge jobs run an extensive battery of tests on several platforms. The -head jobs run the tests on the tip of the submitted code. The -merge jobs run the tests on a merge with the target branch.
+
+The PR-head job runs in public-facing CI every time a pull request is updated.
+
+### High-level overview of the Jenkins test coverage
+
+The Jenkins PR job includes the following parts:
+
+- Run `tests/scripts/all.sh` on Ubuntu 16.04 x86 (64-bit). This script includes:
+    - Some sanity checks.
+    - Tests of the library in various configurations. The tests are mainly unit tests (`make test`), SSL feature tests (`tests/ssl-opt.sh`) and interoperability tests (`tests/compat.sh`).
+    - Some cross compilation with GCC-arm, Arm Compiler 5 (`armcc`), Arm Compiler 6 (`armclang`) and MinGW (`i686-w64-mingw32-gcc`). These are only builds, not tests.
+- Run a subset of `tests/scripts/all.sh` on FreeBSD (amd64)
+- Build on Windows with MinGW and Visual Studio. We use the following Visual Studio versions:
+    - Since Mbed TLS 2.19: VS 2013, 2015, 2017. As of January 2022, we expect to drop VS 2013 soon.
+
+The component names are:
+
+* all_sh-//platform//-//component//: `tests/scripts/all.sh -k `//component// run on //platform//.
+* `code-coverage`: `tests/scripts/basic-build-test.sh` run on Linux (currently Ubuntu 16.04).
+* `win32-mingw`, `win32_msvc12_32`, `win32-msvc12_64`: ad hoc Windows jobs in the default configuration, see below.
+* `Windows-`//20NN//: builds with the specified version of Visual Studio (Visual Studio 10 2010, Visual Studio 12 2013, Visual Studio 14 2015 or Visual Studio 15 2017).
+    * Library configuration: `config.py full` (`config.pl full` in older branches) minus `MBEDTLS_THREADING_xxx`.
+    * Visual Studio configurations: `Release` and `Debug`.
+    * Architectures: `Win32` and `x64` (except no `x64` in VS 2010).
+    * `PlatformToolset` property:
+        * “Retargeted” build: set to the version corresponding to the Visual Studio version for “retargeted” builds.
+        * “Non-retargeted” build: set to `v120` on `development` (C99 code base).
+    * Testing: `selftest.exe`, plus the unit tests in the CMake builds.
+
+The `win32-mingw` component runs the following bat script:
+```
+cmake . -G "MinGW Makefiles" -DCMAKE_C_COMPILER="gcc"
+mingw32-make
+mingw32-make test
+ctest -VV
+programs\test\selftest.exe
+```
+
+The `win32_msvc12_32` component runs the following bat script:
+```
+call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\VC\vcvarsall.bat"
+cmake . -G "Visual Studio 12"
+MSBuild ALL_BUILD.vcxproj
+programs\test\Debug\selftest.exe
+```
+The `win32-msvc12_64` component is identical except that it runs `cmake . -G "Visual Studio 12 Win64"`.
+
+## Tooling
+
+### Tooling for all.sh
+
+To run `tests/scripts/all.sh`, you need at least the following tools:
+
+* basic Unix/POSIX shell utilities. Currently any modern `sh` should do, but a dependency on `bash` may be added in 2020.
+* Git. `all.sh` requires a Git checkout. The following files may be restored to their checked-in version: `include/mbedtls/config.h`, `**/Makefile`.
+
+`all.sh` is composed of many components, some of which have additional requirements. Most components require the following tools:
+
+* `gcc` or `clang` (depending on the component) for native builds.
+* GNU make or CMake (depending on the component).
+* Perl 5.
+* Python ≥3..
+* The commands `openssl`, `gnutls-cli` and `gnutls-serv` must be present in the `$PATH` to run any test component (otherwise `all.sh` refuses to start). If you don't have them, you can still run some test components that don't do any interoperability testing with `env OPENSSL=false GNUTLS_CLI=false GNUTLS_SERV=false tests/scripts/all.sh …`.
+
+### Running `all.sh` on Ubuntu
+
+Our reference Linux platform is Ubuntu 16.04 x86 64-bit. More recent Ubuntu versions should also work.
+
+On Ubuntu 16.04, the following packaged tools are known to cause problems with `all.sh`:
+
+* The `gnutls-bin` package on Ubuntu 16.04 does not work with our test scripts because Ubuntu has removed some obsolete features.
+
+On Ubuntu 20.04, the following packaged tools are known to cause problems with `all.sh`:
+
+* `all.sh check_doxygen_warnings` fails. Doxygen 1.8.11 and 1.8.13 are known to work.
+
+On Ubuntu, for the 32-bit builds, install the following packages:
+```
+apt-get install gcc-multilib libc6-dev-i386 linux-libc-dev:i386 libc6:386
+```
+Instead of `gcc-multilib`, which conflicts with cross-compilers for non-Intel architectures, a versioned package (e.g. `gcc5-multilib`) will do, but you need to create an additional symbolic link:
+```
+ln -s x86_64-linux-gnu/asm /usr/include/asm
+```
+
+### Notes about networking
+
+The tests attempt to establish an IPv6 connection to the local host. This is optional, and will be skipped if IPv6 is not available. However, if IPv6 is possible but IPv6 connections to localhost are blocked by a firewall, the test will fail.
+
+### Docker environment
+
+A Dockerfile is provided in [tests/docker](https://github.com/ARMmbed/mbedtls/tree/development/tests/docker).

--- a/kb/testing/testing-ci.md
+++ b/kb/testing/testing-ci.md
@@ -1,14 +1,14 @@
 # Mbed TLS CI
 
-All code that is included in Mbed TLS must be contributed in the form of [[https://github.com/Mbed-TLS/mbedtls/pulls | pull requests on GitHub]] and undergoes some automated testing. This page describes the continuous integration jobs that run on every pull request.
+All code that is included in Mbed TLS must be contributed in the form of [pull requests on GitHub](https://github.com/Mbed-TLS/mbedtls/pulls) and undergoes some automated testing. This page describes the continuous integration jobs that run on every pull request.
 
 ## DCO
 
-This job checks that all commits have a `Signed-off-by:` line. The presence of this line indicates that the author of the commit certifies that the commit is covered by the [[https://github.com/Mbed-TLS/mbedtls/blob/development/dco.txt | Developer Certificate of Origin]] and contributed according to the [[https://github.com/Mbed-TLS/mbedtls/blob/development/README.md#License | project license]].
+This job checks that all commits have a `Signed-off-by:` line. The presence of this line indicates that the author of the commit certifies that the commit is covered by the [Developer Certificate of Origin](https://github.com/Mbed-TLS/mbedtls/blob/development/dco.txt) and contributed according to the [project license](https://github.com/Mbed-TLS/mbedtls/blob/development/README.md#License).
 
 All commits must have such a line, otherwise the commit cannot be accepted for legal reasons. As a temporary exception, commits from Arm employees or from other contributors who already have a contributor license agreement (CLA) can still be accepted, but please include a `Signed-off-by:` line in any new work.
 
-If the DCO job fails, please reword all commit messages that are missing a `Signed-off-by:` line. If you have multiple commit messages to rewrite, [[https://stackoverflow.com/questions/25570947/how-to-use-git-interactive-rebase-for-signing-off-a-series-of-commits | How to use git interactive rebase for signing off a series of commits]] may help.
+If the DCO job fails, please reword all commit messages that are missing a `Signed-off-by:` line. If you have multiple commit messages to rewrite, [How to use git interactive rebase for signing off a series of commits](https://stackoverflow.com/questions/25570947/how-to-use-git-interactive-rebase-for-signing-off-a-series-of-commits) may help.
 
 ## PR-head and PR-merge jobs
 

--- a/kb/testing/testing-ci.md
+++ b/kb/testing/testing-ci.md
@@ -26,7 +26,7 @@ The Jenkins PR job includes the following parts:
     - Some cross compilation with GCC-arm, Arm Compiler 5 (`armcc`), Arm Compiler 6 (`armclang`) and MinGW (`i686-w64-mingw32-gcc`). These are only builds, not tests.
 - Run a subset of `tests/scripts/all.sh` on FreeBSD (amd64)
 - Build on Windows with MinGW and Visual Studio. We use the following Visual Studio versions:
-    - Since Mbed TLS 2.19: VS 2013, 2015, 2017. As of January 2022, we expect to drop VS 2013 soon.
+    - Since Mbed TLS 2.19: VS 2013, 2015, 2017. As of January 2024, we expect to drop VS 2013 soon.
 
 The component names are:
 

--- a/kb/testing/testing-constant-flow.md
+++ b/kb/testing/testing-constant-flow.md
@@ -78,9 +78,9 @@ From looking at papers, it seems that various researchers are using various cust
 In recent years there seems to be more interest from the programming languages community in eliminating side-channel attacks by providing some form of formal guarantee of safety. These methods usually involve making a new (or modifying a) language/compiler that can detect the incorrect usage of secrets.
 
 References:
-- http://cuda.dcc.ufmg.br/flowtracker/
-- https://ranjitjhala.github.io/static/fact_dsl.pdf
-- https://eprint.iacr.org/2019/1393.pdf#section.4 (section IV, useful summary of recent ideas)
+- <http://cuda.dcc.ufmg.br/flowtracker/>
+- <https://ranjitjhala.github.io/static/fact_dsl.pdf>
+- <https://eprint.iacr.org/2019/1393.pdf#section.4> (section IV, useful summary of recent ideas)
 
 Pros:
 - Often provides some guarantee of safety

--- a/kb/testing/testing-constant-flow.md
+++ b/kb/testing/testing-constant-flow.md
@@ -92,7 +92,7 @@ Cons:
 
 ## Empirical methods
 
-There appears to be some empirical testing tools available for testing constant time code. Tools such as [[ https://github.com/oreparaz/dudect#dudect-dude-is-my-code-constant-time | dudect ]] work by running the program with different inputs and trying to detect statistically different execution times. While these tools may not provide formal guarantees of safety against side-channel attacks it could be a useful, and easy to implement, metric for constant time code.
+There appears to be some empirical testing tools available for testing constant time code. Tools such as [dudect](https://github.com/oreparaz/dudect#dudect-dude-is-my-code-constant-time) work by running the program with different inputs and trying to detect statistically different execution times. While these tools may not provide formal guarantees of safety against side-channel attacks it could be a useful, and easy to implement, metric for constant time code.
 
 ## Compiler support
 

--- a/kb/testing/testing-constant-flow.md
+++ b/kb/testing/testing-constant-flow.md
@@ -64,12 +64,12 @@ Pros:
 Cons:
 - only works with clang on Linux, FreeBSD, NetBSD
 - being compile-time instrumentation, limited with respect to inline assembly
-- for the same reason, misses branches in toolchain-provided functions (for example long multiplication, see Kaufmann et al [^1]) which valgrind would see
+- for the same reason, misses branches in toolchain-provided functions (for example long multiplication, see Kaufmann et al. [^1]) which valgrind would see
 - has an annoying bug where it [misses secret-dependent memory accesses via libc functions](https://github.com/google/sanitizers/issues/1296)
 
 Note: since 2.24.0 we're using this: see `MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN` in `config.h`; components `test_memsan_constant_flow` and ``test_memsan_constant_flow_psa` in `all.sh`; and `tests/suites/test_suite_constant_time`.
 
-[^1]: When Constant-time Source Yields Variable-time Binary: Exploiting Curve25519-donna Built with MSVC 2015. Thierry Kaufmann, Herv ́e Pelletier, Serge Vaudenay, and Karine Villegas. 21 December 2016, Springer Science and Business Media LLC. DOI: 10.1007/978-3-319-48965-0_36. https://core.ac.uk/reader/148026376
+[^1]: When Constant-time Source Yields Variable-time Binary: Exploiting Curve25519-donna Built with MSVC 2015. Thierry Kaufmann, Hervé Pelletier, Serge Vaudenay, and Karine Villegas. 21 December 2016, Springer Science and Business Media LLC. DOI: 10.1007/978-3-319-48965-0_36. https://core.ac.uk/reader/148026376
 
 ### Custom tools
 

--- a/kb/testing/testing-constant-flow.md
+++ b/kb/testing/testing-constant-flow.md
@@ -94,7 +94,7 @@ Cons:
 
 ## Empirical methods
 
-There appears to be some empirical testing tools available for testing constant time code. Tools such as [dudect](https://github.com/oreparaz/dudect#dudect-dude-is-my-code-constant-time) work by running the program with different inputs and trying to detect statistically different execution times. While these tools may not provide formal guarantees of safety against side-channel attacks it could be a useful, and easy to implement, metric for constant time code.
+There appear to be some empirical testing tools available for testing constant time code. Tools such as [dudect](https://github.com/oreparaz/dudect#dudect-dude-is-my-code-constant-time) work by running the program with different inputs and trying to detect statistically different execution times. While these tools may not provide formal guarantees of safety against side-channel attacks it could be a useful, and easy to implement, metric for constant time code.
 
 ## Compiler support
 

--- a/kb/testing/testing-constant-flow.md
+++ b/kb/testing/testing-constant-flow.md
@@ -64,10 +64,12 @@ Pros:
 Cons:
 - only works with clang on Linux, FreeBSD, NetBSD
 - being compile-time instrumentation, limited with respect to inline assembly
-- for the same reason, misses branches in toolchain-provided functions (for example long multiplication, see [this paper](https://core.ac.uk/download/pdf/188281541.pdf)) which valgrind would see
+- for the same reason, misses branches in toolchain-provided functions (for example long multiplication, see Kaufmann et al [^1]) which valgrind would see
 - has an annoying bug where it [misses secret-dependent memory accesses via libc functions](https://github.com/google/sanitizers/issues/1296)
 
 Note: since 2.24.0 we're using this: see `MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN` in `config.h`; components `test_memsan_constant_flow` and ``test_memsan_constant_flow_psa` in `all.sh`; and `tests/suites/test_suite_constant_time`.
+
+[^1]: When Constant-time Source Yields Variable-time Binary: Exploiting Curve25519-donna Built with MSVC 2015. Thierry Kaufmann, Herv ́e Pelletier, Serge Vaudenay, and Karine Villegas. 21 December 2016, Springer Science and Business Media LLC. DOI: 10.1007/978-3-319-48965-0_36. https://core.ac.uk/reader/148026376
 
 ### Custom tools
 

--- a/kb/testing/testing-constant-flow.md
+++ b/kb/testing/testing-constant-flow.md
@@ -1,0 +1,99 @@
+# Tools for testing constant-flow code
+
+Code that manipulates secret values (private keys, etc.) needs to be constant-flow (often called constant-time, though the requirements are actually stricter than "the total running time is a constant"), that is contain no branches that depend on secret values, and no memory accesses at addresses depending on a secret value, in order to avoid leaking the secret value through side channels.
+
+Ideally, this should not only be enforced by code review, but also tested or checked by tools. This pages list some available options.
+
+## Dynamic analyzers
+
+### ctgrind (obsolete)
+
+Listed for historical reference. This was a dynamic library and patch to valgrind, built on the following fundamental observation by its author, Adam Langley:
+
+> This would mean keeping track of every bit in memory to know if it's secret or not, likewise for all the CPU registers. Preferably at the bit level. The tool would also have to know that adding secret and non-secret data results in secret data etc. That suggests that it would be quite a complex tool.
+> But memcheck already does this! In order to keep track of uninitialised data it shadows every bit of memory and will warn you if you use uninitialised data in a branch or to index a memory access. So if we could tell memcheck to treat our secret data as uninitialised, everything should just work.
+
+https://github.com/agl/ctgrind
+
+The project is now obsolete thanks to the options below, which are built on the same idea: (ab)use existing tools checking for use of undefined memory.
+
+### Valgrind's memcheck
+
+It turns out patching valgrind and using a helper library is not necessary, as everything we need is already provided by memcheck: after including `valgrind/memcheck.h` we can use the macros `VALGRIND_MAKE_MEM_UNDEFINED(addr, len)` and `VALGRIND_MAKE_MEM_DEFINED(addr, len)` to mark data as secret (undefined) or no longer secret (defined).
+
+These macros have been available under that name since [3.2.0 (7 June 2006)](https://www.valgrind.org/docs/manual/dist.news.old.html).
+
+References:
+- https://valgrind.org/docs/manual/mc-manual.html
+- https://github.com/mozilla-b2g/valgrind/blob/master/memcheck/memcheck.h
+
+Pros:
+- valgrind/memcheck is already used in our CI
+- large number of [supported architectures/platforms](https://valgrind.org/info/platforms.html)
+- works with any compiler
+- works with inline asm
+- already used by other projects such as [in BoringSSL](https://boringssl.googlesource.com/boringssl/+/a6a049a6fb51a052347611d41583a0622bc89d60)
+
+Cons:
+- just like normal use of valgrind's memcheck, slows down execution by about 20-30x.
+- preliminary testing (by Manuel on a personal project) suggests there may be issues with relative ordering of calls to the macros and use of the values in some uses cases (for example, doing a simple sanity check before marking the value as secret flags the sanity check as accessing undefined memory).
+
+Note: since 2.24.0 we're using this: see `MBEDTLS_TEST_CONSTANT_FLOW_VALGRIND` in `config.h`; components `test_valgrind_constant_flow` and `test_valgrind_constant_flow_psa` in `all.sh`; and `tests/suites/test_suite_constant_time`.
+
+### MemSan
+
+Works in a very similar way to valgrind's memcheck: compiling with `clang -fsanitize=memory`, after including `sanitizer/msan_interface.h`, the two following functions (and a couple more) can be used to mark memory areas as secret/undefined or public/defined.
+```
+  /* Make memory region fully initialized (without changing its contents). */
+  void __msan_unpoison(const volatile void *a, size_t size);
+
+  /* Tell MSan about newly allocated memory (ex.: custom allocator).
+     Memory will be marked uninitialized, with origin at the call site. */
+  void __msan_allocated_memory(const volatile void* data, size_t size);
+```
+
+References:
+- https://clang.llvm.org/docs/MemorySanitizer.html
+- https://github.com/google/sanitizers/wiki/MemorySanitizer
+- https://github.com/llvm-mirror/compiler-rt/blob/master/include/sanitizer/msan_interface.h
+
+Pros:
+- clang/memsan is already used in our CI
+- much faster than valgrind/memcheck (only 2-3x slowdown, so about 10x faster than using valgrind)
+
+Cons:
+- only works with clang on Linux, FreeBSD, NetBSD
+- being compile-time instrumentation, limited with respect to inline assembly
+- for the same reason, misses branches in toolchain-provided functions (for example long multiplication, see [this paper](https://core.ac.uk/download/pdf/188281541.pdf)) which valgrind would see
+- has an annoying bug where it [misses secret-dependent memory accesses via libc functions](https://github.com/google/sanitizers/issues/1296)
+
+Note: since 2.24.0 we're using this: see `MBEDTLS_TEST_CONSTANT_FLOW_MEMSAN` in `config.h`; components `test_memsan_constant_flow` and ``test_memsan_constant_flow_psa` in `all.sh`; and `tests/suites/test_suite_constant_time`.
+
+### Custom tools
+
+From looking at papers, it seems that various researchers are using various custom tools for finding leaks in cryptographic software. However it is unclear if those are publicly available, and being developed by academics mainly for their own use, it's also unclear how easy they would be to deploy on our CI infrastructure.
+
+## Static analyzers and formal guarantees
+
+In recent years there seems to be more interest from the programming languages community in eliminating side-channel attacks by providing some form of formal guarantee of safety. These methods usually involve making a new (or modifying a) language/compiler that can detect the incorrect usage of secrets.
+
+References:
+- http://cuda.dcc.ufmg.br/flowtracker/
+- https://ranjitjhala.github.io/static/fact_dsl.pdf
+- https://eprint.iacr.org/2019/1393.pdf#section.4 (section IV, useful summary of recent ideas)
+
+Pros:
+- Often provides some guarantee of safety
+- Can sometimes transform more readable unsafe code into safe code.
+
+Cons:
+- May involve rewriting sections of constant-time code
+- Still potential for safe code but unsafe binaries
+
+## Empirical methods
+
+There appears to be some empirical testing tools available for testing constant time code. Tools such as [[ https://github.com/oreparaz/dudect#dudect-dude-is-my-code-constant-time | dudect ]] work by running the program with different inputs and trying to detect statistically different execution times. While these tools may not provide formal guarantees of safety against side-channel attacks it could be a useful, and easy to implement, metric for constant time code.
+
+## Compiler support
+
+In my (Manuel) ideal world, we would have some way to tell the compiler "please try hard not introduce branches in this region of the code, and fail loudly if you can't", but I don't think that's available anywhere yet.

--- a/kb/testing/testing-qemu.md
+++ b/kb/testing/testing-qemu.md
@@ -36,7 +36,7 @@ qemu-aarch64 -L /usr/aarch64-linux-gnu ./test_suite_mpi
 
 ### mtest
 
-With [[https://github.com/Mbed-TLS/mbedtls-docs/blob/main/tools/bin/mtest | mtest]]:
+With [mtest](https://github.com/Mbed-TLS/mbedtls-docs/blob/main/tools/bin/mtest):
 
 ```
 mtest <arch> <test names>
@@ -50,7 +50,7 @@ mtest aarch64 cmac
 
 ### mbedtls-prepare-build
 
-With [[https://github.com/ARMmbed/mbedtls-docs/blob/main/tools/bin/mbedtls-prepare-build | mbedtls-prepare-build]]:
+With [mbedtls-prepare-build](https://github.com/ARMmbed/mbedtls-docs/blob/main/tools/bin/mbedtls-prepare-build):
 
 ```
 mbedtls-prepare-build -d build-aarch64 --cc=clang --cflags='-O2 -target aarch64-linux-gnu' --qemu-ld-prefix=aarch64-linux-gnu

--- a/kb/testing/testing-qemu.md
+++ b/kb/testing/testing-qemu.md
@@ -1,0 +1,59 @@
+# Testing non-native architectures with QEMU
+
+This page shows how to test Mbed TLS on Linux for CPUs you don't have, assuming the target CPU can also run Linux.
+
+## Preparing Ubuntu for building and testing with QEMU
+
+Add other targets to your package sources in a new file `/etc/apt/sources.list.d/ubuntu-foreign.list`. Note that ordinary Ubuntu mirrors only have PC builds, so you need a `ports` mirror. For example:
+
+```
+deb [arch=arm64,armhf,ppc64,s390x] http://fr.ports.ubuntu.com/ubuntu-ports focal main restricted universe multiverse
+deb [arch=arm64,armhf,ppc64,s390x] http://fr.ports.ubuntu.com/ubuntu-ports focal-security main restricted universe multiverse
+deb [arch=arm64,armhf,ppc64,s390x] http://fr.ports.ubuntu.com/ubuntu-ports focal-updates main restricted universe multiverse
+```
+
+Then install `libc6-dev` for the desired architectures.
+
+```
+sudo apt-get update
+sudo apt-get install libc6-dev:arm64 libc6-dev:armhf libc6-dev:ppc64 libc6-dev:s390x
+```
+
+## Testing with qemu-user on Linux
+
+### Cmake build
+
+For example for aarch64:
+
+```
+mkdir build-aarch64
+cd build-aarch64
+CC=clang CFLAGS="--target=aarch64-linux-gnu" cmake -DCMAKE_BUILD_TYPE=Release ..
+make -j2
+cd tests
+qemu-aarch64 -L /usr/aarch64-linux-gnu ./test_suite_mpi
+```
+
+### mtest
+
+With [[https://github.com/Mbed-TLS/mbedtls-docs/blob/main/tools/bin/mtest | mtest]]:
+
+```
+mtest <arch> <test names>
+```
+
+e.g.
+
+```
+mtest aarch64 cmac
+```
+
+### mbedtls-prepare-build
+
+With [[https://github.com/ARMmbed/mbedtls-docs/blob/main/tools/bin/mbedtls-prepare-build | mbedtls-prepare-build]]:
+
+```
+mbedtls-prepare-build -d build-aarch64 --cc=clang --cflags='-O2 -target aarch64-linux-gnu' --qemu-ld-prefix=aarch64-linux-gnu
+make -C build-aarch64 test
+```
+

--- a/kb/testing/testing-qemu.md
+++ b/kb/testing/testing-qemu.md
@@ -50,7 +50,7 @@ mtest aarch64 cmac
 
 ### mbedtls-prepare-build
 
-With [mbedtls-prepare-build](https://github.com/ARMmbed/mbedtls-docs/blob/main/tools/bin/mbedtls-prepare-build):
+With [mbedtls-prepare-build](https://github.com/Mbed-TLS/mbedtls-docs/blob/main/tools/bin/mbedtls-prepare-build):
 
 ```
 mbedtls-prepare-build -d build-aarch64 --cc=clang --cflags='-O2 -target aarch64-linux-gnu' --qemu-ld-prefix=aarch64-linux-gnu

--- a/project/vulnerabilities.md
+++ b/project/vulnerabilities.md
@@ -2,7 +2,7 @@
 
 ## Reporting a vulnerability
 
-If you think you have found an Mbed TLS security vulnerability, then please send an email to the security team at [mailto:mbed-tls-security@lists.trustedfirmware.org]. For more information on the reporting and disclosure process, please see the [TrustedFirmware.org security incident handling process](https://developer.trustedfirmware.org/w/collaboration/security_center/reporting/). There are some caveats to that process when applied to Mbed TLS, as listed below:
+If you think you have found an Mbed TLS security vulnerability, then please send an email to the security team at <mailto:mbed-tls-security@lists.trustedfirmware.org>. For more information on the reporting and disclosure process, please see the [TrustedFirmware.org security incident handling process](https://developer.trustedfirmware.org/w/collaboration/security_center/reporting/). There are some caveats to that process when applied to Mbed TLS, as listed below:
 
 - Mbed TLS currently does not have any registered ESSes and so there is no primary embargo period.
 -  Mbed TLS contains strong cryptography software and to comply with export control restrictions, must only distribute software publicly. As a result, security fixes cannot be shared privately with Trusted Stakeholders, although other vulnerability information can be.

--- a/project/vulnerabilities.md
+++ b/project/vulnerabilities.md
@@ -1,0 +1,14 @@
+# Security Vulnerability Processes
+
+## Reporting a vulnerability
+
+If you think you have found an Mbed TLS security vulnerability, then please send an email to the security team at [[mailto:mbed-tls-security@lists.trustedfirmware.org]]. For more information on the reporting and disclosure process, please see the   [[ https://developer.trustedfirmware.org/w/collaboration/security_center/reporting/ | TrustedFirmware.org security incident handling process ]]. There are some caveats to that process when applied to Mbed TLS, as listed below:
+
+- Mbed TLS currently does not have any registered ESSes and so there is no primary embargo period.
+-  Mbed TLS contains strong cryptography software and to comply with export control restrictions, must only distribute software publicly. As a result, security fixes cannot be shared privately with Trusted Stakeholders, although other vulnerability information can be.
+- The nature of Mbed TLS often means that security fixes reveal enough information for a skilled attacker to re-construct the originally reported exploit. This combined with the previous caveat means we often expect to have to withhold security fixes until the public disclosure date.
+- Mbed TLS is subject to a lot of scrutiny by security researchers who often have their own disclosure timelines when reporting vulnerabilities. As a result, the default 90 days public embargo period may often not apply.
+
+## Advisories
+
+Please see (the security advisories page)[../security-advisories/index.md] for a complete list of Mbed TLS security advisories.

--- a/project/vulnerabilities.md
+++ b/project/vulnerabilities.md
@@ -2,7 +2,7 @@
 
 ## Reporting a vulnerability
 
-If you think you have found an Mbed TLS security vulnerability, then please send an email to the security team at [[mailto:mbed-tls-security@lists.trustedfirmware.org]]. For more information on the reporting and disclosure process, please see the   [[ https://developer.trustedfirmware.org/w/collaboration/security_center/reporting/ | TrustedFirmware.org security incident handling process ]]. There are some caveats to that process when applied to Mbed TLS, as listed below:
+If you think you have found an Mbed TLS security vulnerability, then please send an email to the security team at [mailto:mbed-tls-security@lists.trustedfirmware.org]. For more information on the reporting and disclosure process, please see the [TrustedFirmware.org security incident handling process](https://developer.trustedfirmware.org/w/collaboration/security_center/reporting/). There are some caveats to that process when applied to Mbed TLS, as listed below:
 
 - Mbed TLS currently does not have any registered ESSes and so there is no primary embargo period.
 -  Mbed TLS contains strong cryptography software and to comply with export control restrictions, must only distribute software publicly. As a result, security fixes cannot be shared privately with Trusted Stakeholders, although other vulnerability information can be.
@@ -11,4 +11,4 @@ If you think you have found an Mbed TLS security vulnerability, then please send
 
 ## Advisories
 
-Please see (the security advisories page)[../security-advisories/index.md] for a complete list of Mbed TLS security advisories.
+Please see [the security advisories page](../security-advisories/index.md) for a complete list of Mbed TLS security advisories.

--- a/reviews/review-priorities.md
+++ b/reviews/review-priorities.md
@@ -23,7 +23,7 @@ Same criteria as priority-high, below, but needed for the Mbed TLS team's most i
 This classification is often used for vulnerability fixes with a public disclosure date.
 
 
-## priority-high and 
+## priority-high
 
 This classification is used for PRs which have a target date for merging - typically one of:
 


### PR DESCRIPTION
Port remaining phabricator wiki content:

- security centre (ie vulnerability reporting process)
- notes on testing

I've lightly updated the testing notes - there may still be some out-of-date info but I've tried to fix all the major things. I've removed some things that tend to go out of date (e.g. list of supported tool versions).

Non-critical out-of-date things can be fixed in a follow-up and shouldn't scope-creep this PR.

Part of review: please confirm that I haven't missed any useful content from Phabricator https://developer.trustedfirmware.org/w/mbed-tls/