### PR TITLE
PrivateKey inside PrivateKeyInfo should be OCTET STRING

### DIFF
--- a/kb/cryptography/asn1-key-structures-in-der-and-pem.md
+++ b/kb/cryptography/asn1-key-structures-in-der-and-pem.md
@@ -47,8 +47,8 @@ Within the base64 encoded data, the following DER structure is present:
 
 ```
     RSAPublicKey ::= SEQUENCE {
-    modulus   INTEGER,  -- n
-    publicExponentINTEGER   -- e
+      modulus   INTEGER,  -- n
+      publicExponent    INTEGER   -- e
     }
 ```
 
@@ -96,10 +96,10 @@ Within the base64 encoded data, the following DER structure is present:
     RSAPrivateKey ::= SEQUENCE {
       version   Version,
       modulus   INTEGER,  -- n
-      publicExponentINTEGER,  -- e
+      publicExponent    INTEGER,  -- e
       privateExponent   INTEGER,  -- d
-      prime1INTEGER,  -- p
-      prime2INTEGER,  -- q
+      prime1    INTEGER,  -- p
+      prime2    INTEGER,  -- q
       exponent1 INTEGER,  -- d mod (p-1)
       exponent2 INTEGER,  -- d mod (q-1)
       coefficient   INTEGER,  -- (inverse of q) mod p
@@ -148,7 +148,7 @@ Within the base64 encoded data, the following DER structure is present:
 ```
     EncryptedPrivateKeyInfo ::= SEQUENCE {
       encryptionAlgorithm  EncryptionAlgorithmIdentifier,
-      encryptedDataEncryptedData
+      encryptedData    EncryptedData
     }
     
     EncryptionAlgorithmIdentifier ::= AlgorithmIdentifier

--- a/kb/cryptography/asn1-key-structures-in-der-and-pem.md
+++ b/kb/cryptography/asn1-key-structures-in-der-and-pem.md
@@ -124,7 +124,7 @@ Within the base64 encoded data, the following DER structure is present:
     PrivateKeyInfo ::= SEQUENCE {
       version Version,
       algorithm   AlgorithmIdentifier,
-      PrivateKey  BIT STRING
+      PrivateKey  OCTET STRING
     }
     
     AlgorithmIdentifier ::= SEQUENCE {
@@ -133,7 +133,7 @@ Within the base64 encoded data, the following DER structure is present:
     }
 ```
 
-So for an RSA private key, the OID is `1.2.840.113549.1.1.1`, and the `RSAPrivateKey` is the `PrivateKey` key data bitstring.
+So for an RSA private key, the OID is `1.2.840.113549.1.1.1`, and the `RSAPrivateKey` is the `PrivateKey` key data octet string.
 
 The encrypted PKCS#8 encoded data starts and ends with the tags:
 


### PR DESCRIPTION
Hi there,

from my testing, the private key generated with openssl has OCTET STRING instead of BIT STRING to contain the RSAPrivateKey.

Also fix representations of some DER structures.