### PR TITLE
mbedtls-kick-ci: Restore defaulting to the mbedtls repository

### DIFF
--- a/tools/bin/mbedtls-kick-ci
+++ b/tools/bin/mbedtls-kick-ci
@@ -107,7 +107,7 @@ case "$PR" in
         # No merge job in the framework
         ;;
     m*|[0-9]*)
-        PR="${PR#?}"
+        PR="${PR#m}"
         HEAD_JOB="mbed-tls-pr-head"
         MERGE_JOB="mbed-tls-pr-merge"
         ;;


### PR DESCRIPTION
This was accidentally broken when adding support for TF-PSA-Crypto.