### PR TITLE
Add missing credit for the `mbedtls_ssl_set_hostname()` issue

### DIFF
--- a/security-advisories/mbedtls-security-advisory-2025-03-1.md
+++ b/security-advisories/mbedtls-security-advisory-2025-03-1.md
@@ -6,6 +6,7 @@
 **Date** | 24 March 2025
 **Affects** | All versions of PolarSSL and Mbed TLS
 **Severity** | HIGH
+**Credit** | Daniel Stenberg
 
 ## Vulnerability
 


### PR DESCRIPTION
Correctly credit Daniel Stenberg as the reporter, which was previously missed.