### PR TITLE
Fix bug in mbedtls-kick-ci

### DIFF
--- a/tools/bin/mbedtls-kick-ci
+++ b/tools/bin/mbedtls-kick-ci
@@ -106,8 +106,12 @@ case "$PR" in
         HEAD_JOB="mbed-tls-framework-multibranch"
         # No merge job in the framework
         ;;
-    m*|[0-9]*)
+    m*)
         PR="${PR#?}"
+        HEAD_JOB="mbed-tls-pr-head"
+        MERGE_JOB="mbed-tls-pr-merge"
+        ;;
+    [0-9]*)
         HEAD_JOB="mbed-tls-pr-head"
         MERGE_JOB="mbed-tls-pr-merge"
         ;;


### PR DESCRIPTION
When a number is supplied with no prefix, we are meant to assume Mbed TLS by default. This we do, but we also remove the first digit of the PR number inadvertantly.

Fix this so that the PR number is interpreted correctly as referring to Mbed TLS and starts the correct CI.