### PR TITLE
Add top-level headers

### DIFF
--- a/security-advisories/mbedtls-security-advisory-2025-06-3.md
+++ b/security-advisories/mbedtls-security-advisory-2025-06-3.md
@@ -1,3 +1,5 @@
+# Unchecked return value in LMS verification allows signature bypass
+
 **Title** | Unchecked return value in LMS verification allows signature bypass
 --------- | ----------------------------------------------------------
 **CVE** | CVE-2025-49600

--- a/security-advisories/mbedtls-security-advisory-2025-06-4.md
+++ b/security-advisories/mbedtls-security-advisory-2025-06-4.md
@@ -1,3 +1,5 @@
+# Out-of-bounds read in mbedtls_lms_import_public_key()
+
 **Title** | Out-of-bounds read in mbedtls_lms_import_public_key()
 --------- | ----------------------------------------------------------
 **CVE** | CVE-2025-49601


### PR DESCRIPTION
Without them, the list of advisory at [1] looks all wrong because it then picks level-2 headers (Vulnerability, Impact, etc.) instead.

https://mbed-tls.readthedocs.io/en/latest/security-advisories/